### PR TITLE
Pass the handled deep-link object to targetViewController in DPLRouteHandler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,8 +18,8 @@ profile
 DerivedData
 *.hmap
 *.ipa
+*.gcda
+*.gcno
 
 # Bundler
 .bundle
-
-Pods/

--- a/DeepLinkKit.xcodeproj/project.pbxproj
+++ b/DeepLinkKit.xcodeproj/project.pbxproj
@@ -663,6 +663,7 @@
 				6003F587195388D20070C39A /* Frameworks */,
 				6003F588195388D20070C39A /* Resources */,
 				213419298EA5AA6429BEFD28 /* Copy Pods Resources */,
+				301E0C292A94F97EC822C770 /* Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -682,6 +683,7 @@
 				6003F5AB195388D20070C39A /* Frameworks */,
 				6003F5AC195388D20070C39A /* Resources */,
 				0D3359342B62D92CA67C2E04 /* Copy Pods Resources */,
+				DB90A76236059A91115FB124 /* Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -702,6 +704,7 @@
 				62335DD31B57003300E3818C /* Frameworks */,
 				62335DD41B57003300E3818C /* Resources */,
 				9AC6E46B330C620FAB6621E4 /* Copy Pods Resources */,
+				CD0B69B60F7AE7388A393191 /* Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -721,6 +724,7 @@
 				DEDB148A1A3F944D00A837F8 /* Frameworks */,
 				DEDB148B1A3F944D00A837F8 /* Resources */,
 				82E3829DCB61E29D4B984C4F /* Copy Pods Resources */,
+				3FE98E8813CF0D288A8E9A3A /* Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -738,7 +742,8 @@
 			isa = PBXProject;
 			attributes = {
 				CLASSPREFIX = DPL;
-				LastUpgradeCheck = 0610;
+				LastSwiftUpdateCheck = 0710;
+				LastUpgradeCheck = 0710;
 				ORGANIZATIONNAME = "Button, Inc.";
 				TargetAttributes = {
 					6003F5AD195388D20070C39A = {
@@ -859,6 +864,21 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-ReceiverDemo/Pods-ReceiverDemo-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
+		301E0C292A94F97EC822C770 /* Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-ReceiverDemo/Pods-ReceiverDemo-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		32310565C7E21C1120BDDD58 /* Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -887,6 +907,21 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		3FE98E8813CF0D288A8E9A3A /* Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-SenderDemo/Pods-SenderDemo-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		7E4A77AFF27B0E5465184209 /* Check Pods Manifest.lock */ = {
@@ -932,6 +967,36 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-ReceiverDemoSwift/Pods-ReceiverDemoSwift-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		CD0B69B60F7AE7388A393191 /* Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-ReceiverDemoSwift/Pods-ReceiverDemoSwift-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		DB90A76236059A91115FB124 /* Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Tests/Pods-Tests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -1061,6 +1126,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_GENERATE_TEST_COVERAGE_FILES = YES;
@@ -1129,6 +1195,7 @@
 				GCC_PREFIX_HEADER = "SampleApps/ReceiverDemo/SupportingFiles/ReceiverDemo-Prefix.pch";
 				INFOPLIST_FILE = "SampleApps/ReceiverDemo/SupportingFiles/ReceiverDemo-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.usebutton.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TARGETED_DEVICE_FAMILY = 1;
 				WRAPPER_EXTENSION = app;
@@ -1145,6 +1212,7 @@
 				GCC_PREFIX_HEADER = "SampleApps/ReceiverDemo/SupportingFiles/ReceiverDemo-Prefix.pch";
 				INFOPLIST_FILE = "SampleApps/ReceiverDemo/SupportingFiles/ReceiverDemo-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.usebutton.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TARGETED_DEVICE_FAMILY = 1;
 				WRAPPER_EXTENSION = app;
@@ -1159,6 +1227,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Tests/SupportingFiles/Tests-Prefix.pch";
 				INFOPLIST_FILE = "Tests/SupportingFiles/Tests-Info.plist";
+				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ReceiverDemo.app/ReceiverDemo";
 				WRAPPER_EXTENSION = xctest;
@@ -1173,6 +1242,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Tests/SupportingFiles/Tests-Prefix.pch";
 				INFOPLIST_FILE = "Tests/SupportingFiles/Tests-Info.plist";
+				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ReceiverDemo.app/ReceiverDemo";
 				WRAPPER_EXTENSION = xctest;
@@ -1205,6 +1275,7 @@
 					"-fprofile-arcs",
 					"-ftest-coverage",
 				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.usebutton.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "SampleApps/ReceiverDemoSwift/ReceiverDemoSwift-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -1235,6 +1306,7 @@
 					"-fprofile-arcs",
 					"-ftest-coverage",
 				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.usebutton.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "SampleApps/ReceiverDemoSwift/ReceiverDemoSwift-Bridging-Header.h";
 				TARGETED_DEVICE_FAMILY = 1;
@@ -1264,6 +1336,7 @@
 					"-fprofile-arcs",
 					"-ftest-coverage",
 				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.usebutton.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "SampleApps/ReceiverDemoSwift/ReceiverDemoSwift-Bridging-Header.h";
 				TARGETED_DEVICE_FAMILY = 1;
@@ -1322,6 +1395,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				INFOPLIST_FILE = "SampleApps/ReceiverDemo/SupportingFiles/ReceiverDemo-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.usebutton.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TARGETED_DEVICE_FAMILY = 1;
 				WRAPPER_EXTENSION = app;
@@ -1345,6 +1419,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.usebutton.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TARGETED_DEVICE_FAMILY = 1;
 			};
@@ -1358,6 +1433,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Tests/SupportingFiles/Tests-Prefix.pch";
 				INFOPLIST_FILE = "Tests/SupportingFiles/Tests-Info.plist";
+				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ReceiverDemo.app/ReceiverDemo";
 				WRAPPER_EXTENSION = xctest;
@@ -1381,6 +1457,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.usebutton.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TARGETED_DEVICE_FAMILY = 1;
 			};
@@ -1399,6 +1476,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.usebutton.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TARGETED_DEVICE_FAMILY = 1;
 			};

--- a/DeepLinkKit.xcodeproj/xcshareddata/xcschemes/ReceiverDemo.xcscheme
+++ b/DeepLinkKit.xcodeproj/xcshareddata/xcschemes/ReceiverDemo.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0610"
+   LastUpgradeVersion = "0710"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -23,10 +23,10 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
+      buildConfiguration = "Test"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Test">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -48,17 +48,21 @@
             ReferencedContainer = "container:DeepLinkKit.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <BuildableProductRunnable>
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "6003F589195388D20070C39A"
@@ -71,12 +75,13 @@
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
+      buildConfiguration = "Release"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
-      <BuildableProductRunnable>
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "6003F589195388D20070C39A"

--- a/DeepLinkKit.xcodeproj/xcshareddata/xcschemes/SenderDemo.xcscheme
+++ b/DeepLinkKit.xcodeproj/xcshareddata/xcschemes/SenderDemo.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0610"
+   LastUpgradeVersion = "0710"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -37,10 +37,10 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
+      buildConfiguration = "Test"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Test">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -62,15 +62,18 @@
             ReferencedContainer = "container:DeepLinkKit.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">
@@ -86,10 +89,10 @@
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
+      buildConfiguration = "Release"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">

--- a/DeepLinkKit/Regex/DPLRegularExpression.m
+++ b/DeepLinkKit/Regex/DPLRegularExpression.m
@@ -15,7 +15,8 @@ static NSString * const DPLURLParameterPattern        = @"([^/]+)";
                         options:(NSRegularExpressionOptions)options
                           error:(NSError *__autoreleasing *)error {
     
-    NSString *cleanedPattern = [[self class] stringByRemovingNamedGroupsFromString:pattern];
+    NSString *cleanedPattern = [[self class] stringByExpandingWildcardComponents:pattern];
+    cleanedPattern = [[self class] stringByRemovingNamedGroupsFromString:cleanedPattern];
     
     self = [super initWithPattern:cleanedPattern options:options error:error];
     if (self) {
@@ -69,6 +70,13 @@ static NSString * const DPLURLParameterPattern        = @"([^/]+)";
     return [NSArray arrayWithArray:namedGroupTokens];
 }
 
++ (NSString *)stringByExpandingWildcardComponents:(NSString *)pattern
+{
+    pattern = [pattern stringByReplacingOccurrencesOfString:@"*" withString:@"#*#"];
+    pattern = [pattern stringByReplacingOccurrencesOfString:@"#*##*#" withString:@"(?:.*?)"];
+    pattern = [pattern stringByReplacingOccurrencesOfString:@"#*#" withString:@"(?:[^/]+?)"];
+    return pattern;
+}
 
 + (NSString *)stringByRemovingNamedGroupsFromString:(NSString *)str {
     NSString *modifiedStr = [str copy];

--- a/DeepLinkKit/Regex/DPLRegularExpression.m
+++ b/DeepLinkKit/Regex/DPLRegularExpression.m
@@ -2,7 +2,7 @@
 
 static NSString * const DPLNamedGroupComponentPattern = @":[a-zA-Z0-9-_][^/]+";
 static NSString * const DPLRouteParameterPattern      = @":[a-zA-Z0-9-_]+";
-static NSString * const DPLURLParameterPattern        = @"([^/]+)";
+static NSString * const DPLURLParameterPattern        = @"([^/]*)";
 
 @implementation DPLRegularExpression
 

--- a/DeepLinkKit/RouteHandler/DPLRouteHandler.h
+++ b/DeepLinkKit/RouteHandler/DPLRouteHandler.h
@@ -33,13 +33,21 @@
  */
 - (BOOL)preferModalPresentation;
 
+
+/**
+ The view controller class that will be presented as a result of the deep link.
+ @param deepLink A deep link instance.
+ @return A view controller class, conforming to the `DPLTargetViewController' protocol.
+ @note Subclasses MUST override this method.
+ */
+- (Class<DPLTargetViewController>)targetViewControllerClassForDeepLink:(DPLDeepLink *)deepLink;
+
 /**
  The view controller that will be presented as a result of the deep link.
  @param deepLink A deep link instance.
  @return A view controller conforming to the `DPLTargetViewController' protocol.
  @note Subclasses MUST override this method.
  */
-
 - (UIViewController <DPLTargetViewController> *)targetViewControllerForDeepLink:(DPLDeepLink *)deepLink;
 
 /**

--- a/DeepLinkKit/RouteHandler/DPLRouteHandler.h
+++ b/DeepLinkKit/RouteHandler/DPLRouteHandler.h
@@ -33,14 +33,14 @@
  */
 - (BOOL)preferModalPresentation;
 
-
 /**
  The view controller that will be presented as a result of the deep link.
+ @param deepLink A deep link instance.
  @return A view controller conforming to the `DPLTargetViewController' protocol.
  @note Subclasses MUST override this method.
  */
-- (UIViewController <DPLTargetViewController> *)targetViewController;
 
+- (UIViewController <DPLTargetViewController> *)targetViewControllerForDeepLink:(DPLDeepLink *)deepLink;
 
 /**
  Specifies the view controller from which to present a `targetViewController'.
@@ -67,5 +67,19 @@
  */
 - (void)presentTargetViewController:(UIViewController <DPLTargetViewController> *)targetViewController
                    inViewController:(UIViewController *)presentingViewController;
+
+@end
+
+
+@interface DPLRouteHandler (Deprecated)
+
+
+/**
+ The view controller that will be presented as a result of the deep link.
+ @return A view controller conforming to the `DPLTargetViewController' protocol.
+ @note Subclasses MUST override this method.
+ */
+- (UIViewController <DPLTargetViewController> *)targetViewController __attribute__((deprecated("Use targetViewControllerForDeepLink: instead")));
+
 
 @end

--- a/DeepLinkKit/RouteHandler/DPLRouteHandler.m
+++ b/DeepLinkKit/RouteHandler/DPLRouteHandler.m
@@ -12,15 +12,13 @@
 }
 
 
-- (UIViewController <DPLTargetViewController> *)targetViewController {
-    return nil;
-}
-
-
 - (UIViewController *)viewControllerForPresentingDeepLink:(DPLDeepLink *)deepLink {
     return [UIApplication sharedApplication].keyWindow.rootViewController;
 }
 
+- (UIViewController<DPLTargetViewController> *)targetViewControllerForDeepLink:(DPLDeepLink *)deepLink {
+    return nil;
+}
 
 - (void)presentTargetViewController:(UIViewController <DPLTargetViewController> *)targetViewController
                    inViewController:(UIViewController *)presentingViewController {
@@ -66,6 +64,15 @@
             [navigationController pushViewController:targetViewController animated:NO];
         }
     }
+}
+
+@end
+
+
+@implementation DPLRouteHandler (Deprecated)
+
+- (UIViewController <DPLTargetViewController> *)targetViewController {
+    return [self targetViewControllerForDeepLink:nil];
 }
 
 @end

--- a/DeepLinkKit/RouteHandler/DPLRouteHandler.m
+++ b/DeepLinkKit/RouteHandler/DPLRouteHandler.m
@@ -16,11 +16,13 @@
     return [UIApplication sharedApplication].keyWindow.rootViewController;
 }
 
+- (Class<DPLTargetViewController>)targetViewControllerClassForDeepLink:(DPLDeepLink *)deepLink {
+    return nil;
+}
+
 - (UIViewController<DPLTargetViewController> *)targetViewControllerForDeepLink:(DPLDeepLink *)deepLink {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    return [self targetViewController];
-#pragma clang diagnostic pop
+    Class targetVCClass = [self targetViewControllerClassForDeepLink:deepLink];
+    return [targetVCClass new];
 }
 
 - (void)presentTargetViewController:(UIViewController <DPLTargetViewController> *)targetViewController

--- a/DeepLinkKit/RouteHandler/DPLRouteHandler.m
+++ b/DeepLinkKit/RouteHandler/DPLRouteHandler.m
@@ -17,7 +17,10 @@
 }
 
 - (UIViewController<DPLTargetViewController> *)targetViewControllerForDeepLink:(DPLDeepLink *)deepLink {
-    return nil;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    return [self targetViewController];
+#pragma clang diagnostic pop
 }
 
 - (void)presentTargetViewController:(UIViewController <DPLTargetViewController> *)targetViewController
@@ -72,7 +75,7 @@
 @implementation DPLRouteHandler (Deprecated)
 
 - (UIViewController <DPLTargetViewController> *)targetViewController {
-    return [self targetViewControllerForDeepLink:nil];
+    return nil;
 }
 
 @end

--- a/DeepLinkKit/Router/DPLDeepLinkRouter.h
+++ b/DeepLinkKit/Router/DPLDeepLinkRouter.h
@@ -85,6 +85,13 @@ typedef void(^DPLRouteCompletionBlock)(BOOL handled, NSError *error);
  */
 - (BOOL)handleURL:(NSURL *)url withCompletion:(DPLRouteCompletionBlock)completionHandler;
 
+/**
+ Attempts to find the class of the target view controller for an incoming URL.
+ This might be useful when you have a URL and want full control on how to instantiate/present the target view controller.
+ @param url The incoming URL from `application:openURL:sourceApplication:annotation:'
+ @return the target view controller class for the incoming URL, Nil if the URL is not handled
+ */
+- (Class<DPLTargetViewController>)targetViewControllerClassForURL:(NSURL *)url;
 
 /**
  Attempts to find the target view controller for an incoming URL. 

--- a/DeepLinkKit/Router/DPLDeepLinkRouter.h
+++ b/DeepLinkKit/Router/DPLDeepLinkRouter.h
@@ -2,7 +2,7 @@
 
 @class    DPLDeepLink;
 @protocol DPLRouteHandler;
-
+@protocol DPLTargetViewController;
 
 /**
  Defines the block type to be used as the handler when registering a route.
@@ -85,6 +85,14 @@ typedef void(^DPLRouteCompletionBlock)(BOOL handled, NSError *error);
  */
 - (BOOL)handleURL:(NSURL *)url withCompletion:(DPLRouteCompletionBlock)completionHandler;
 
+
+/**
+ Attempts to find the target view controller for an incoming URL. 
+ This might be useful when you have a URL and want full control on how to present the target view controller.
+ @param url The incoming URL from `application:openURL:sourceApplication:annotation:'
+ @return the target view controller for the incoming URL, nil if the URL is not handled
+ */
+- (UIViewController<DPLTargetViewController> *)targetViewControllerForURL:(NSURL *)url;
 
 /**
  Attempts to handle an incoming user activity.

--- a/DeepLinkKit/Router/DPLDeepLinkRouter.m
+++ b/DeepLinkKit/Router/DPLDeepLinkRouter.m
@@ -149,12 +149,18 @@
 
 - (UIViewController<DPLTargetViewController> *)targetViewControllerForURL:(NSURL *)url
 {
+    Class targetVCClass = [self targetViewControllerClassForURL:url];
+    return [[targetVCClass alloc] init];
+}
+
+- (Class<DPLTargetViewController>)targetViewControllerClassForURL:(NSURL *)url
+{
     if (!url) {
-        return nil;
+        return Nil;
     }
     
     if (![self applicationCanHandleDeepLinks]) {
-        return nil;
+        return Nil;
     }
     
     DPLDeepLink  *deepLink;
@@ -164,19 +170,18 @@
         if (deepLink) {
             id handler = self[route];
             if (!class_isMetaClass(object_getClass(handler)) || ![handler isSubclassOfClass:[DPLRouteHandler class]]) {
-                return nil;
+                return Nil;
             }
             DPLRouteHandler *routeHandler = [[handler alloc] init];
-            UIViewController<DPLTargetViewController> *targetViewController = [routeHandler targetViewControllerForDeepLink:deepLink];
+            Class targetVCClass = [routeHandler targetViewControllerClassForDeepLink:deepLink];
             
-            if (targetViewController) {
-                [targetViewController configureWithDeepLink:deepLink];
-                return targetViewController;
+            if (targetVCClass) {
+                return targetVCClass;
             }
             break;
         }
     }
-    return nil;
+    return Nil;
 }
 
 - (BOOL)handleRoute:(NSString *)route withDeepLink:(DPLDeepLink *)deepLink error:(NSError *__autoreleasing *)error {

--- a/DeepLinkKit/Router/DPLDeepLinkRouter.m
+++ b/DeepLinkKit/Router/DPLDeepLinkRouter.m
@@ -164,7 +164,7 @@
         }
         
         UIViewController *presentingViewController = [routeHandler viewControllerForPresentingDeepLink:deepLink];
-        UIViewController <DPLTargetViewController> *targetViewController = [routeHandler targetViewController];
+        UIViewController <DPLTargetViewController> *targetViewController = [routeHandler targetViewControllerForDeepLink:deepLink];
         
         if (targetViewController) {
             [targetViewController configureWithDeepLink:deepLink];

--- a/DeepLinkKit/Router/DPLDeepLinkRouter.m
+++ b/DeepLinkKit/Router/DPLDeepLinkRouter.m
@@ -147,6 +147,37 @@
     return NO;
 }
 
+- (UIViewController<DPLTargetViewController> *)targetViewControllerForURL:(NSURL *)url
+{
+    if (!url) {
+        return nil;
+    }
+    
+    if (![self applicationCanHandleDeepLinks]) {
+        return nil;
+    }
+    
+    DPLDeepLink  *deepLink;
+    for (NSString *route in self.routes) {
+        DPLRouteMatcher *matcher = [DPLRouteMatcher matcherWithRoute:route];
+        deepLink = [matcher deepLinkWithURL:url];
+        if (deepLink) {
+            id handler = self[route];
+            if (!class_isMetaClass(object_getClass(handler)) || ![handler isSubclassOfClass:[DPLRouteHandler class]]) {
+                return nil;
+            }
+            DPLRouteHandler *routeHandler = [[handler alloc] init];
+            UIViewController<DPLTargetViewController> *targetViewController = [routeHandler targetViewControllerForDeepLink:deepLink];
+            
+            if (targetViewController) {
+                [targetViewController configureWithDeepLink:deepLink];
+                return targetViewController;
+            }
+            break;
+        }
+    }
+    return nil;
+}
 
 - (BOOL)handleRoute:(NSString *)route withDeepLink:(DPLDeepLink *)deepLink error:(NSError *__autoreleasing *)error {
     id handler = self[route];

--- a/SampleApps/ReceiverDemo/SupportingFiles/ReceiverDemo-Info.plist
+++ b/SampleApps/ReceiverDemo/SupportingFiles/ReceiverDemo-Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.usebutton.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/SampleApps/ReceiverDemoSwift/Info.plist
+++ b/SampleApps/ReceiverDemoSwift/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.usebutton.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/SampleApps/SenderDemo/SupportingFiles/SenderDemo-Info.plist
+++ b/SampleApps/SenderDemo/SupportingFiles/SenderDemo-Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.usebutton.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Tests/SupportingFiles/Tests-Info.plist
+++ b/Tests/SupportingFiles/Tests-Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleIdentifier</key>
-	<string>org.cocoapods.demo.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundlePackageType</key>


### PR DESCRIPTION
In some cases, we need to be able to have different target view controllers for the same route, presenting a different UI depending on `routeParameters` or `queryParameters` of the link for example.

I have added `[DPLRouteHandler targetViewControllerForDeepLink:]` replacing the now deprecated `targetViewController`.

Backwards compatibility is preserved, since the new method is calling `[DPLRouteHandler  targetViewController]`. So no change is required to existing code using DeepLinkKit.

I also updated the project to comply with the new Xcode 7's recommended settings.
