### PR TITLE
Removing unneeded specta includes in test specs

### DIFF
--- a/Tests/Categories/NSObject_DPLJSONObjectSpec.m
+++ b/Tests/Categories/NSObject_DPLJSONObjectSpec.m
@@ -1,4 +1,3 @@
-#import "Specta.h"
 #import "NSObject+DPLJSONObject.h"
 #import "DPLSerializableObject.h"
 

--- a/Tests/Categories/NSString_DPLJSONSpec.m
+++ b/Tests/Categories/NSString_DPLJSONSpec.m
@@ -1,4 +1,3 @@
-#import "Specta.h"
 #import "NSString+DPLJSON.h"
 
 SpecBegin(NSString_DPLJSON)

--- a/Tests/Categories/NSString_DPLQuerySpec.m
+++ b/Tests/Categories/NSString_DPLQuerySpec.m
@@ -1,4 +1,3 @@
-#import "Specta.h"
 #import "NSString+DPLQuery.h"
 
 SpecBegin(NSString_DPLQuery)

--- a/Tests/Categories/NSString_DPLTrimSpec.m
+++ b/Tests/Categories/NSString_DPLTrimSpec.m
@@ -1,4 +1,3 @@
-#import "Specta.h"
 #import "NSString+DPLTrim.h"
 
 SpecBegin(NSString_DPLTrim)

--- a/Tests/DeepLink/DPLDeepLinkSpec.m
+++ b/Tests/DeepLink/DPLDeepLinkSpec.m
@@ -1,4 +1,3 @@
-#import "Specta.h"
 #import "DPLDeepLink.h"
 #import "DPLDeepLink_Private.h"
 #import "DPLMutableDeepLink.h"

--- a/Tests/DeepLink/DPLDeepLink_AppLinksSpec.m
+++ b/Tests/DeepLink/DPLDeepLink_AppLinksSpec.m
@@ -1,4 +1,3 @@
-#import "Specta.h"
 @import DeepLinkKit.Private;
 @import DeepLinkKit.AppLinks;
 

--- a/Tests/DeepLink/DPLMutableDeepLinkSpec.m
+++ b/Tests/DeepLink/DPLMutableDeepLinkSpec.m
@@ -1,4 +1,3 @@
-#import "Specta.h"
 #import "DPLMutableDeepLink.h"
 #import "DPLDeepLink_Private.h"
 

--- a/Tests/DeepLink/DPLMutableDeepLink_AppLinksSpec.m
+++ b/Tests/DeepLink/DPLMutableDeepLink_AppLinksSpec.m
@@ -1,4 +1,3 @@
-#import "Specta.h"
 #import "DPLMutableDeepLink+AppLinks.h"
 #import "DPLDeepLink_Private.h"
 

--- a/Tests/Regex/DPLRegularExpressionSpec.m
+++ b/Tests/Regex/DPLRegularExpressionSpec.m
@@ -1,4 +1,3 @@
-#import "Specta.h"
 #import "DPLRegularExpression.h"
 
 SpecBegin(DPLRegularExpression)

--- a/Tests/RouteMatcher/DPLRouteMatcherSpec.m
+++ b/Tests/RouteMatcher/DPLRouteMatcherSpec.m
@@ -1,4 +1,3 @@
-#import "Specta.h"
 #import "DPLRouteMatcher.h"
 #import "DPLDeepLink.h"
 

--- a/Tests/Router/DPLDeepLinkRouterSpec.m
+++ b/Tests/Router/DPLDeepLinkRouterSpec.m
@@ -1,4 +1,3 @@
-#import "Specta.h"
 #import "DPLDeepLinkRouter.h"
 #import "DPLDeepLinkRouter_Private.h"
 #import "DPLRouteHandler.h"


### PR DESCRIPTION
As it is stated in [specta example](https://github.com/specta/specta#example), there's no need to do #include "Specta.h"