### PR TITLE
Removing unneeded specta includes in test specs, part 2

### DIFF
--- a/Tests/Categories/UINavigationController_DPLRoutingSpec.m
+++ b/Tests/Categories/UINavigationController_DPLRoutingSpec.m
@@ -1,4 +1,3 @@
-#import "Specta.h"
 #import "UINavigationController+DPLRouting.h"
 
 @interface VC1 : UIViewController @end


### PR DESCRIPTION
Continuation of PR #96 .
Missed newly created Test Spec (UINavigationController_DPLRoutingSpec.m) from yesterday's commit.