### PR TITLE
Update Slather config

### DIFF
--- a/.slather.yml
+++ b/.slather.yml
@@ -1,3 +1,7 @@
 coverage_service: coveralls
 xcodeproj: DeepLinkKit.xcodeproj
-source_directory: DeepLinkKit
+workspace: DeepLinkKit.xcworkspace
+scheme: ReceiverDemo
+ignore:
+  - Pods/*
+  - Tests/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ before_install:
 script:
   - xctool test -workspace DeepLinkKit.xcworkspace -scheme ReceiverDemo -sdk iphonesimulator ONLY_ACTIVE_ARCH=NO
 after_success:
-  - slather
+  - slather coverage -s --scheme ReceiverDemo --workspace DeepLinkKit.xcworkspace DeepLinkKit.xcodeproj

--- a/DeepLinkKit.xcodeproj/project.pbxproj
+++ b/DeepLinkKit.xcodeproj/project.pbxproj
@@ -1223,7 +1223,8 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
-				CLANG_ENABLE_CODE_COVERAGE = NO;
+				CLANG_ENABLE_CODE_COVERAGE = YES;
+				GCC_GENERATE_TEST_COVERAGE_FILES = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "SampleApps/ReceiverDemo/SupportingFiles/ReceiverDemo-Prefix.pch";
 				INFOPLIST_FILE = "SampleApps/ReceiverDemo/SupportingFiles/ReceiverDemo-Info.plist";
@@ -1241,7 +1242,8 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
-				CLANG_ENABLE_CODE_COVERAGE = NO;
+				CLANG_ENABLE_CODE_COVERAGE = YES;
+				GCC_GENERATE_TEST_COVERAGE_FILES = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "SampleApps/ReceiverDemo/SupportingFiles/ReceiverDemo-Prefix.pch";
 				INFOPLIST_FILE = "SampleApps/ReceiverDemo/SupportingFiles/ReceiverDemo-Info.plist";
@@ -1399,7 +1401,8 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
-				CLANG_ENABLE_CODE_COVERAGE = NO;
+				CLANG_ENABLE_CODE_COVERAGE = YES;
+				GCC_GENERATE_TEST_COVERAGE_FILES = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "SampleApps/ReceiverDemo/SupportingFiles/ReceiverDemo-Prefix.pch";
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";

--- a/DeepLinkKit.xcodeproj/xcshareddata/xcschemes/SenderDemo.xcscheme
+++ b/DeepLinkKit.xcodeproj/xcshareddata/xcschemes/SenderDemo.xcscheme
@@ -40,7 +40,8 @@
       buildConfiguration = "Test"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (4.2.4)
+    activesupport (4.2.6)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
@@ -42,13 +42,18 @@ GEM
     fuzzy_match (2.0.4)
     i18n (0.7.0)
     json (1.8.3)
-    minitest (5.8.1)
-    molinillo (0.4.0)
-    nap (1.0.0)
+    mini_portile2 (2.0.0)
+    minitest (5.8.4)
+    molinillo (0.4.4)
+    nap (1.1.0)
     netrc (0.7.8)
-    slather (1.3.0)
+    nokogiri (1.6.7.2)
+      mini_portile2 (~> 2.0.0.rc2)
+    rouge (1.10.1)
+    slather (2.1.0)
       clamp (~> 0.6)
-      xcodeproj (~> 0.17)
+      nokogiri (~> 1.6.3)
+      xcodeproj (>= 0.28.2, < 1.1.0)
     thread_safe (0.3.5)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
@@ -56,7 +61,8 @@ GEM
       activesupport (>= 3)
       claide (~> 0.9.1)
       colored (~> 1.2)
-    xcpretty (0.1.12)
+    xcpretty (0.2.2)
+      rouge (~> 1.8)
 
 PLATFORMS
   ruby
@@ -67,4 +73,4 @@ DEPENDENCIES
   xcpretty
 
 BUNDLED WITH
-   1.10.6
+   1.11.2


### PR DESCRIPTION
This should reactivate Slather builds on [Coveralls](https://coveralls.io/github/button/DeepLinkKit).

My results locally:

```
SampleApps/ReceiverDemo/DPLReceiverAppDelegate.m: 17 of 33 lines (51.52%)
SampleApps/ReceiverDemo/ProductData/DPLProduct.m: 13 of 13 lines (100.00%)
SampleApps/ReceiverDemo/ProductData/DPLProductDataSource.m: 20 of 36 lines (55.56%)
SampleApps/ReceiverDemo/ProductDetail/DPLProductDetailViewController.m: 13 of 13 lines (100.00%)
SampleApps/ReceiverDemo/ProductList/DPLProductTableViewController.m: 0 of 17 lines (0.00%)
SampleApps/ReceiverDemo/RouteHandlers/DPLProductRouteHandler.m: 5 of 5 lines (100.00%)
SampleApps/ReceiverDemo/SupportingFiles/main.m: 5 of 5 lines (100.00%)
Test Coverage: 60.16%
Slathered
```

Note: it looks like `DPLProductTableViewController.m` needs some tests :smile: 
