### PR TITLE
#111 - registerHandlerClass:forRoute: interface is generated for Swift 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ branches:
   only:
     master
 before_install:
-  - gem install activesupport -N
+  - gem install activesupport -N -v 4.2.6
   - gem install slather --no-rdoc --no-ri --no-document --quiet
   - gem i cocoapods --no-ri --no-rdoc
   - pod install

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,7 @@ branches:
   only:
     master
 before_install:
-  - gem install activesupport -N -v 4.2.6
-  - gem install slather --no-rdoc --no-ri --no-document --quiet
-  - gem i cocoapods --no-ri --no-rdoc
+  - bundle
   - pod install
 script:
   - xctool test -workspace DeepLinkKit.xcworkspace -scheme ReceiverDemo -sdk iphonesimulator ONLY_ACTIVE_ARCH=NO

--- a/DeepLinkKit/Router/DPLDeepLinkRouter.h
+++ b/DeepLinkKit/Router/DPLDeepLinkRouter.h
@@ -1,7 +1,6 @@
 @import Foundation;
 
-@class    DPLDeepLink;
-@protocol DPLRouteHandler;
+@class DPLDeepLink;
 
 
 /**
@@ -48,7 +47,7 @@ typedef void(^DPLRouteCompletionBlock)(BOOL handled, NSError *error);
  For example, you can register a class for a route as follows:
  @code deepLinkRouter[@"table/book/:id"] = [MyBookingRouteHandler class]; @endcode
  */
-- (void)registerHandlerClass:(Class <DPLRouteHandler>)handlerClass forRoute:(NSString *)route;
+- (void)registerHandlerClass:(Class)handlerClass forRoute:(NSString *)route;
 
 
 /**

--- a/DeepLinkKit/Router/DPLDeepLinkRouter.m
+++ b/DeepLinkKit/Router/DPLDeepLinkRouter.m
@@ -42,9 +42,9 @@
 
 #pragma mark - Registering Routes
 
-- (void)registerHandlerClass:(Class <DPLRouteHandler>)handlerClass forRoute:(NSString *)route {
+- (void)registerHandlerClass:(Class)handlerClass forRoute:(NSString *)route {
 
-    if (handlerClass && [route length]) {
+    if (handlerClass && [handlerClass isSubclassOfClass:[DPLRouteHandler class]] && [route length]) {
         [self.routes addObject:route];
         [self.blocksByRoute removeObjectForKey:route];
         self.classesByRoute[route] = handlerClass;

--- a/Tests/Router/DPLDeepLinkRouterSpec.m
+++ b/Tests/Router/DPLDeepLinkRouterSpec.m
@@ -29,8 +29,18 @@ describe(@"Registering Routes", ^{
         expect(router[route]).to.equal([DPLRouteHandler class]);
     });
     
+    it(@"registers a class for a route with registerHandlerClass:forRoute:", ^{
+        [router registerHandlerClass:[DPLRouteHandler class] forRoute:route];
+        expect(router[route]).to.equal([DPLRouteHandler class]);
+    });
+    
     it(@"does NOT register a class not conforming to DPLRouteHandler protocol", ^{
         router[route] = [NSObject class];
+        expect(router[route]).to.beNil();
+    });
+    
+    it(@"does NOT register not a subclass of DPLRouteHandler with registerHandlerClass:forRoute:", ^{
+        [router registerHandlerClass:[NSObject class] forRoute:route];
         expect(router[route]).to.beNil();
     });
     


### PR DESCRIPTION
Looks like specialized Class is not interfacing with Swift and declaration for
```
- (void)registerHandlerClass:(Class <DPLRouteHandler>)handlerClass forRoute:(NSString *)route;
```
can't be generated.