### PR TITLE
Fixes DPLRouteMatcher Incorrectly Matching URL Without Host or Path

### DIFF
--- a/DeepLinkKit/RouteMatcher/DPLRouteMatcher.m
+++ b/DeepLinkKit/RouteMatcher/DPLRouteMatcher.m
@@ -37,7 +37,7 @@
 - (DPLDeepLink *)deepLinkWithURL:(NSURL *)url {
     
     DPLDeepLink *deepLink       = [[DPLDeepLink alloc] initWithURL:url];
-    NSString *deepLinkString    = [NSString stringWithFormat:@"%@%@", deepLink.URL.host, deepLink.URL.path];
+    NSString *deepLinkString    = [NSString stringWithFormat:@"%@%@", deepLink.URL.host ?: @"", deepLink.URL.path ?: @""];
     
     if (self.scheme.length && ![self.scheme isEqualToString:deepLink.URL.scheme]) {
         return nil;


### PR DESCRIPTION
Closes #114

See details at #114. This prevents a URL with just a scheme from being matched to a route that has a single variable. The example given at #114 is the following route registration:

```objc
self.router[@":log_message"] = ^(DPLDeepLink *link) {
    NSLog(@"%@", link[@"log_message"]);
};
```

This should properly log `hello` for the URL `dpl://hello` in the ReceiverDemo sample project. The block, however, should not execute for `dpl://`. Before this change, it would execute and log the string `(null)(null)`.