### PR TITLE
Extend the DPLRouteHandler and DPLDeepLinkRouter to support asynchronous targets

### DIFF
--- a/DeepLinkKit.xcodeproj/project.pbxproj
+++ b/DeepLinkKit.xcodeproj/project.pbxproj
@@ -8,10 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		2F4988DE1AE71ABC0069EF2B /* DPLRouteHandlerIntegrationTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 2F4988DD1AE71ABC0069EF2B /* DPLRouteHandlerIntegrationTest.m */; };
-		4AEEDB1E39AECEBE74DEC785 /* Pods_ReceiverDemoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EC3E153594BC11ACCA16FACF /* Pods_ReceiverDemoSwift.framework */; };
-		4B891C24F5FC37AB411B3CFE /* Pods_SenderDemo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0B177EEF374212F61E2F88E2 /* Pods_SenderDemo.framework */; };
 		4D4F412B1B02A96400B710DB /* DPLRegularExpressionSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 4D4F412A1B02A96400B710DB /* DPLRegularExpressionSpec.m */; };
-		59F0E57564C24FFB8BD121EC /* Pods_ReceiverDemo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ACBE42039CA1306AF612E45E /* Pods_ReceiverDemo.framework */; };
 		6003F58E195388D20070C39A /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F58D195388D20070C39A /* Foundation.framework */; };
 		6003F590195388D20070C39A /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F58F195388D20070C39A /* CoreGraphics.framework */; };
 		6003F592195388D20070C39A /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F591195388D20070C39A /* UIKit.framework */; };
@@ -29,7 +26,9 @@
 		62EE96F61B570B10003D7564 /* DPLProductDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = DE025EB01A5F0D37007C4F3A /* DPLProductDataSource.m */; };
 		62EE96F71B570B13003D7564 /* DPLProduct.m in Sources */ = {isa = PBXBuildFile; fileRef = DE87B1F01A5DF49F00204A35 /* DPLProduct.m */; };
 		62EE96F81B570B16003D7564 /* DPLProductTableViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = DEAD327A19E079D3003C8D65 /* DPLProductTableViewController.m */; };
-		BCA80D0137FDB7D7BDCE4B1D /* Pods_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 939E4800884A5EF9BDEBAA95 /* Pods_Tests.framework */; };
+		67C46D94DC68E22D70018D4A /* Pods_SenderDemo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 26835292B4AF23266C39DDA9 /* Pods_SenderDemo.framework */; };
+		885BF817236F484E7F5F73E2 /* Pods_ReceiverDemo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AF5DF65B06CA8F8FF3D9C377 /* Pods_ReceiverDemo.framework */; };
+		C4DC1B03379071F87259E123 /* Pods_ReceiverDemoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 67EA2BDC55F6B8A61FDF5848 /* Pods_ReceiverDemoSwift.framework */; };
 		DE025EB11A5F0D37007C4F3A /* DPLProductDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = DE025EB01A5F0D37007C4F3A /* DPLProductDataSource.m */; };
 		DE058E0A1A3B46FD00147C04 /* NSString_DPLQuerySpec.m in Sources */ = {isa = PBXBuildFile; fileRef = DE058E091A3B46FD00147C04 /* NSString_DPLQuerySpec.m */; };
 		DE058E101A3B485500147C04 /* DPLDeepLinkSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = DE058E0F1A3B485500147C04 /* DPLDeepLinkSpec.m */; };
@@ -63,6 +62,7 @@
 		DEE40E5F1A42B0530097EA33 /* DPLActionDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = DEE40E5D1A42ABE80097EA33 /* DPLActionDataSource.m */; };
 		DEE40E601A42B0580097EA33 /* DPLDemoAction.m in Sources */ = {isa = PBXBuildFile; fileRef = DEE40E581A42A3F50097EA33 /* DPLDemoAction.m */; };
 		DEEBD4A91AAB7946000BCA84 /* DPLSerializableObject.m in Sources */ = {isa = PBXBuildFile; fileRef = DEEBD4A81AAB7946000BCA84 /* DPLSerializableObject.m */; };
+		E0C96A5E8453EE6A52BFEAC4 /* Pods_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2E79E61BF60D104F5BFCBBC4 /* Pods_Tests.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -76,37 +76,39 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		0B177EEF374212F61E2F88E2 /* Pods_SenderDemo.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SenderDemo.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		14A1857A6611A826E51F612A /* Pods-ReceiverDemo.test.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ReceiverDemo.test.xcconfig"; path = "Pods/Target Support Files/Pods-ReceiverDemo/Pods-ReceiverDemo.test.xcconfig"; sourceTree = "<group>"; };
-		2AE3E05821FBC0C05F248E61 /* Pods-Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Tests/Pods-Tests.debug.xcconfig"; sourceTree = "<group>"; };
+		209B78B65FD39733D22E6684 /* Pods-Tests.test.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tests.test.xcconfig"; path = "Pods/Target Support Files/Pods-Tests/Pods-Tests.test.xcconfig"; sourceTree = "<group>"; };
+		26835292B4AF23266C39DDA9 /* Pods_SenderDemo.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SenderDemo.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		2E79E61BF60D104F5BFCBBC4 /* Pods_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		2F4988DD1AE71ABC0069EF2B /* DPLRouteHandlerIntegrationTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = DPLRouteHandlerIntegrationTest.m; path = IntegrationTests/DPLRouteHandlerIntegrationTest.m; sourceTree = "<group>"; };
+		38C242B13D70274A4052BF29 /* Pods-ReceiverDemo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ReceiverDemo.release.xcconfig"; path = "Pods/Target Support Files/Pods-ReceiverDemo/Pods-ReceiverDemo.release.xcconfig"; sourceTree = "<group>"; };
 		4D4F412A1B02A96400B710DB /* DPLRegularExpressionSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DPLRegularExpressionSpec.m; sourceTree = "<group>"; };
-		57D5F02E049D7887B4F4ACDF /* Pods-ReceiverDemo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ReceiverDemo.debug.xcconfig"; path = "Pods/Target Support Files/Pods-ReceiverDemo/Pods-ReceiverDemo.debug.xcconfig"; sourceTree = "<group>"; };
-		59C6806DC6FB049E0A3371C7 /* Pods-ReceiverDemoSwift.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ReceiverDemoSwift.release.xcconfig"; path = "Pods/Target Support Files/Pods-ReceiverDemoSwift/Pods-ReceiverDemoSwift.release.xcconfig"; sourceTree = "<group>"; };
+		578651A2E783C4C2A9BD41AE /* Pods-Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tests.release.xcconfig"; path = "Pods/Target Support Files/Pods-Tests/Pods-Tests.release.xcconfig"; sourceTree = "<group>"; };
+		592B45ECC86F96F2EC4E064B /* Pods-ReceiverDemo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ReceiverDemo.debug.xcconfig"; path = "Pods/Target Support Files/Pods-ReceiverDemo/Pods-ReceiverDemo.debug.xcconfig"; sourceTree = "<group>"; };
+		5FD0C3709C171E9583FCA4B0 /* Pods-Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Tests/Pods-Tests.debug.xcconfig"; sourceTree = "<group>"; };
 		6003F58A195388D20070C39A /* ReceiverDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ReceiverDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		6003F58D195388D20070C39A /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		6003F58F195388D20070C39A /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
 		6003F591195388D20070C39A /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 		6003F5AE195388D20070C39A /* Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		61496AE0E4E7CC07D76C8402 /* Pods-SenderDemo.test.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SenderDemo.test.xcconfig"; path = "Pods/Target Support Files/Pods-SenderDemo/Pods-SenderDemo.test.xcconfig"; sourceTree = "<group>"; };
+		61CCA9DC9B40CF38E6FF673E /* Pods-ReceiverDemoSwift.test.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ReceiverDemoSwift.test.xcconfig"; path = "Pods/Target Support Files/Pods-ReceiverDemoSwift/Pods-ReceiverDemoSwift.test.xcconfig"; sourceTree = "<group>"; };
 		62335DD61B57003300E3818C /* ReceiverDemoSwift.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ReceiverDemoSwift.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		62335DFB1B57007F00E3818C /* DPLReceiverSwiftAppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DPLReceiverSwiftAppDelegate.swift; sourceTree = "<group>"; };
 		62335E011B57007F00E3818C /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		62891E8A1B57FE5A00C2AF4F /* DPLMessageRouteHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DPLMessageRouteHandler.swift; sourceTree = "<group>"; };
 		62EE96F11B57011D003D7564 /* ReceiverDemoSwift-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "ReceiverDemoSwift-Bridging-Header.h"; sourceTree = "<group>"; };
 		62EE96F31B570891003D7564 /* DPLProductRouteHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DPLProductRouteHandler.swift; sourceTree = "<group>"; };
-		6B9E60301031FFD1833ECA7A /* Pods-SenderDemo.test.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SenderDemo.test.xcconfig"; path = "Pods/Target Support Files/Pods-SenderDemo/Pods-SenderDemo.test.xcconfig"; sourceTree = "<group>"; };
+		67EA2BDC55F6B8A61FDF5848 /* Pods_ReceiverDemoSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ReceiverDemoSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		7EA840098917BE391CCC70A3 /* Pods-ReceiverDemoSwift.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ReceiverDemoSwift.release.xcconfig"; path = "Pods/Target Support Files/Pods-ReceiverDemoSwift/Pods-ReceiverDemoSwift.release.xcconfig"; sourceTree = "<group>"; };
 		83D34C3B1B03ECAD00BA6EF1 /* DPLMatchResult.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DPLMatchResult.h; sourceTree = "<group>"; };
 		83D34C3C1B03ECAD00BA6EF1 /* DPLMatchResult.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = DPLMatchResult.m; sourceTree = "<group>"; };
 		83D34C3D1B03ECAD00BA6EF1 /* DPLRegularExpression.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DPLRegularExpression.h; sourceTree = "<group>"; };
 		83D34C3E1B03ECAD00BA6EF1 /* DPLRegularExpression.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = DPLRegularExpression.m; sourceTree = "<group>"; };
 		8949A4E8F681A12A47C20775 /* DeepLinkKit.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; name = DeepLinkKit.podspec; path = ./DeepLinkKit.podspec; sourceTree = "<group>"; };
-		939E4800884A5EF9BDEBAA95 /* Pods_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		A7644D9D2D35BA2869AD63FA /* Pods-SenderDemo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SenderDemo.release.xcconfig"; path = "Pods/Target Support Files/Pods-SenderDemo/Pods-SenderDemo.release.xcconfig"; sourceTree = "<group>"; };
-		ACBE42039CA1306AF612E45E /* Pods_ReceiverDemo.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ReceiverDemo.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		B3CB044233E227F87FCF2C46 /* Pods-Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tests.release.xcconfig"; path = "Pods/Target Support Files/Pods-Tests/Pods-Tests.release.xcconfig"; sourceTree = "<group>"; };
-		B915356798E84DC8F8A0A3CB /* Pods-SenderDemo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SenderDemo.debug.xcconfig"; path = "Pods/Target Support Files/Pods-SenderDemo/Pods-SenderDemo.debug.xcconfig"; sourceTree = "<group>"; };
-		BB75E70100C0775F382CD22F /* Pods-ReceiverDemo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ReceiverDemo.release.xcconfig"; path = "Pods/Target Support Files/Pods-ReceiverDemo/Pods-ReceiverDemo.release.xcconfig"; sourceTree = "<group>"; };
-		BBE7E5A25C1B0E9637BE745A /* Pods-Tests.test.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tests.test.xcconfig"; path = "Pods/Target Support Files/Pods-Tests/Pods-Tests.test.xcconfig"; sourceTree = "<group>"; };
+		8B39E6D8A0A13F29A011AD50 /* Pods-ReceiverDemo.test.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ReceiverDemo.test.xcconfig"; path = "Pods/Target Support Files/Pods-ReceiverDemo/Pods-ReceiverDemo.test.xcconfig"; sourceTree = "<group>"; };
+		ABBF002169DAC24E56B80100 /* Pods-ReceiverDemoSwift.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ReceiverDemoSwift.debug.xcconfig"; path = "Pods/Target Support Files/Pods-ReceiverDemoSwift/Pods-ReceiverDemoSwift.debug.xcconfig"; sourceTree = "<group>"; };
+		AF5DF65B06CA8F8FF3D9C377 /* Pods_ReceiverDemo.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ReceiverDemo.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		BD3690E1AFBEEBE817A4D9AE /* Pods-SenderDemo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SenderDemo.debug.xcconfig"; path = "Pods/Target Support Files/Pods-SenderDemo/Pods-SenderDemo.debug.xcconfig"; sourceTree = "<group>"; };
 		DE025EAF1A5F0D37007C4F3A /* DPLProductDataSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DPLProductDataSource.h; sourceTree = "<group>"; };
 		DE025EB01A5F0D37007C4F3A /* DPLProductDataSource.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DPLProductDataSource.m; sourceTree = "<group>"; };
 		DE058E071A3B46F500147C04 /* NSString+DPLQuery.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSString+DPLQuery.h"; sourceTree = "<group>"; };
@@ -191,9 +193,7 @@
 		DEEBD4A81AAB7946000BCA84 /* DPLSerializableObject.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = DPLSerializableObject.m; path = Fixtures/DPLSerializableObject.m; sourceTree = "<group>"; };
 		DF9272621ECB6C2824AD5C94 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = LICENSE; path = ./LICENSE; sourceTree = "<group>"; };
 		E9CA1DB95577CF3689F4B77F /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ./README.md; sourceTree = "<group>"; };
-		EC3E153594BC11ACCA16FACF /* Pods_ReceiverDemoSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ReceiverDemoSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		FB774EA6D84A50233F032ADC /* Pods-ReceiverDemoSwift.test.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ReceiverDemoSwift.test.xcconfig"; path = "Pods/Target Support Files/Pods-ReceiverDemoSwift/Pods-ReceiverDemoSwift.test.xcconfig"; sourceTree = "<group>"; };
-		FBD5C3C0EA400B61BE35A3E4 /* Pods-ReceiverDemoSwift.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ReceiverDemoSwift.debug.xcconfig"; path = "Pods/Target Support Files/Pods-ReceiverDemoSwift/Pods-ReceiverDemoSwift.debug.xcconfig"; sourceTree = "<group>"; };
+		F6318D3E0D685F995698A23C /* Pods-SenderDemo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SenderDemo.release.xcconfig"; path = "Pods/Target Support Files/Pods-SenderDemo/Pods-SenderDemo.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -204,7 +204,7 @@
 				6003F590195388D20070C39A /* CoreGraphics.framework in Frameworks */,
 				6003F592195388D20070C39A /* UIKit.framework in Frameworks */,
 				6003F58E195388D20070C39A /* Foundation.framework in Frameworks */,
-				59F0E57564C24FFB8BD121EC /* Pods_ReceiverDemo.framework in Frameworks */,
+				885BF817236F484E7F5F73E2 /* Pods_ReceiverDemo.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -214,7 +214,7 @@
 			files = (
 				6003F5B2195388D20070C39A /* UIKit.framework in Frameworks */,
 				6003F5B1195388D20070C39A /* Foundation.framework in Frameworks */,
-				BCA80D0137FDB7D7BDCE4B1D /* Pods_Tests.framework in Frameworks */,
+				E0C96A5E8453EE6A52BFEAC4 /* Pods_Tests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -225,7 +225,7 @@
 				62335E0B1B5700BC00E3818C /* UIKit.framework in Frameworks */,
 				62335E0A1B5700B400E3818C /* CoreGraphics.framework in Frameworks */,
 				62335E091B5700AF00E3818C /* Foundation.framework in Frameworks */,
-				4AEEDB1E39AECEBE74DEC785 /* Pods_ReceiverDemoSwift.framework in Frameworks */,
+				C4DC1B03379071F87259E123 /* Pods_ReceiverDemoSwift.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -236,7 +236,7 @@
 				DE16E91A1A4254E100077E18 /* CoreGraphics.framework in Frameworks */,
 				DE16E9181A4254D200077E18 /* UIKit.framework in Frameworks */,
 				DE16E9191A4254D900077E18 /* Foundation.framework in Frameworks */,
-				4B891C24F5FC37AB411B3CFE /* Pods_SenderDemo.framework in Frameworks */,
+				67C46D94DC68E22D70018D4A /* Pods_SenderDemo.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -251,21 +251,21 @@
 			name = IntegrationTests;
 			sourceTree = "<group>";
 		};
-		439F76E40704ACAAE4203F56 /* Pods */ = {
+		4685F9E19F79465057FA9522 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				2AE3E05821FBC0C05F248E61 /* Pods-Tests.debug.xcconfig */,
-				B3CB044233E227F87FCF2C46 /* Pods-Tests.release.xcconfig */,
-				57D5F02E049D7887B4F4ACDF /* Pods-ReceiverDemo.debug.xcconfig */,
-				BB75E70100C0775F382CD22F /* Pods-ReceiverDemo.release.xcconfig */,
-				B915356798E84DC8F8A0A3CB /* Pods-SenderDemo.debug.xcconfig */,
-				A7644D9D2D35BA2869AD63FA /* Pods-SenderDemo.release.xcconfig */,
-				14A1857A6611A826E51F612A /* Pods-ReceiverDemo.test.xcconfig */,
-				6B9E60301031FFD1833ECA7A /* Pods-SenderDemo.test.xcconfig */,
-				BBE7E5A25C1B0E9637BE745A /* Pods-Tests.test.xcconfig */,
-				FBD5C3C0EA400B61BE35A3E4 /* Pods-ReceiverDemoSwift.debug.xcconfig */,
-				FB774EA6D84A50233F032ADC /* Pods-ReceiverDemoSwift.test.xcconfig */,
-				59C6806DC6FB049E0A3371C7 /* Pods-ReceiverDemoSwift.release.xcconfig */,
+				592B45ECC86F96F2EC4E064B /* Pods-ReceiverDemo.debug.xcconfig */,
+				8B39E6D8A0A13F29A011AD50 /* Pods-ReceiverDemo.test.xcconfig */,
+				38C242B13D70274A4052BF29 /* Pods-ReceiverDemo.release.xcconfig */,
+				ABBF002169DAC24E56B80100 /* Pods-ReceiverDemoSwift.debug.xcconfig */,
+				61CCA9DC9B40CF38E6FF673E /* Pods-ReceiverDemoSwift.test.xcconfig */,
+				7EA840098917BE391CCC70A3 /* Pods-ReceiverDemoSwift.release.xcconfig */,
+				BD3690E1AFBEEBE817A4D9AE /* Pods-SenderDemo.debug.xcconfig */,
+				61496AE0E4E7CC07D76C8402 /* Pods-SenderDemo.test.xcconfig */,
+				F6318D3E0D685F995698A23C /* Pods-SenderDemo.release.xcconfig */,
+				5FD0C3709C171E9583FCA4B0 /* Pods-Tests.debug.xcconfig */,
+				209B78B65FD39733D22E6684 /* Pods-Tests.test.xcconfig */,
+				578651A2E783C4C2A9BD41AE /* Pods-Tests.release.xcconfig */,
 			);
 			name = Pods;
 			sourceTree = "<group>";
@@ -287,7 +287,7 @@
 				DEAD328119E079D3003C8D65 /* Tests */,
 				6003F58C195388D20070C39A /* Frameworks */,
 				6003F58B195388D20070C39A /* Products */,
-				439F76E40704ACAAE4203F56 /* Pods */,
+				4685F9E19F79465057FA9522 /* Pods */,
 			);
 			sourceTree = "<group>";
 		};
@@ -308,10 +308,10 @@
 				6003F58D195388D20070C39A /* Foundation.framework */,
 				6003F58F195388D20070C39A /* CoreGraphics.framework */,
 				6003F591195388D20070C39A /* UIKit.framework */,
-				ACBE42039CA1306AF612E45E /* Pods_ReceiverDemo.framework */,
-				EC3E153594BC11ACCA16FACF /* Pods_ReceiverDemoSwift.framework */,
-				0B177EEF374212F61E2F88E2 /* Pods_SenderDemo.framework */,
-				939E4800884A5EF9BDEBAA95 /* Pods_Tests.framework */,
+				AF5DF65B06CA8F8FF3D9C377 /* Pods_ReceiverDemo.framework */,
+				67EA2BDC55F6B8A61FDF5848 /* Pods_ReceiverDemoSwift.framework */,
+				26835292B4AF23266C39DDA9 /* Pods_SenderDemo.framework */,
+				2E79E61BF60D104F5BFCBBC4 /* Pods_Tests.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -678,12 +678,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 6003F5BF195388D20070C39A /* Build configuration list for PBXNativeTarget "ReceiverDemo" */;
 			buildPhases = (
-				32310565C7E21C1120BDDD58 /* Check Pods Manifest.lock */,
+				A997E6273B854D3BA550C0D9 /* [CP] Check Pods Manifest.lock */,
 				6003F586195388D20070C39A /* Sources */,
 				6003F587195388D20070C39A /* Frameworks */,
 				6003F588195388D20070C39A /* Resources */,
-				213419298EA5AA6429BEFD28 /* Copy Pods Resources */,
-				4025AE564DBFB183CA53A923 /* Embed Pods Frameworks */,
+				BFA144B635D937E26209A8F7 /* [CP] Embed Pods Frameworks */,
+				AFC605485982ED3785CAA667 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -698,13 +698,13 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 6003F5C2195388D20070C39A /* Build configuration list for PBXNativeTarget "Tests" */;
 			buildPhases = (
-				19DDAD1B81E630617AA38624 /* Check Pods Manifest.lock */,
+				36278AF8AB494B5291DEBF73 /* [CP] Check Pods Manifest.lock */,
 				6003F5AA195388D20070C39A /* Sources */,
 				6003F5AB195388D20070C39A /* Frameworks */,
 				6003F5AC195388D20070C39A /* Resources */,
-				0D3359342B62D92CA67C2E04 /* Copy Pods Resources */,
-				A891777DE50BB01821DC55E8 /* Embed Pods Frameworks */,
 				DE56F9AB1BD6B0140090BF8C /* Specta Focus Check */,
+				DBEE9C72636742AC90485FCE /* [CP] Embed Pods Frameworks */,
+				DAD2C47D044A830C1DAF082E /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -720,12 +720,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 62335DF81B57003400E3818C /* Build configuration list for PBXNativeTarget "ReceiverDemoSwift" */;
 			buildPhases = (
-				34BE96D877C65145E7951D75 /* Check Pods Manifest.lock */,
+				F88B971AF55760DF339BFF53 /* [CP] Check Pods Manifest.lock */,
 				62335DD21B57003300E3818C /* Sources */,
 				62335DD31B57003300E3818C /* Frameworks */,
 				62335DD41B57003300E3818C /* Resources */,
-				9AC6E46B330C620FAB6621E4 /* Copy Pods Resources */,
-				F7AECAC5E12B21557769080B /* Embed Pods Frameworks */,
+				884395904B9A828AD2F8664B /* [CP] Embed Pods Frameworks */,
+				29F4946D30704ABCEAD9DA22 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -740,12 +740,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = DEDB14AD1A3F944E00A837F8 /* Build configuration list for PBXNativeTarget "SenderDemo" */;
 			buildPhases = (
-				7E4A77AFF27B0E5465184209 /* Check Pods Manifest.lock */,
+				EA622D12052DB0D9D115BA41 /* [CP] Check Pods Manifest.lock */,
 				DEDB14891A3F944D00A837F8 /* Sources */,
 				DEDB148A1A3F944D00A837F8 /* Frameworks */,
 				DEDB148B1A3F944D00A837F8 /* Resources */,
-				82E3829DCB61E29D4B984C4F /* Copy Pods Resources */,
-				3D9B225BD699DD9D3E3783DD /* Embed Pods Frameworks */,
+				3B628DE034011539408FDD07 /* [CP] Embed Pods Frameworks */,
+				2193990D6C68E0C164841942 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -839,134 +839,14 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		0D3359342B62D92CA67C2E04 /* Copy Pods Resources */ = {
+		2193990D6C68E0C164841942 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Tests/Pods-Tests-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		19DDAD1B81E630617AA38624 /* Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Check Pods Manifest.lock";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
-			showEnvVarsInLog = 0;
-		};
-		213419298EA5AA6429BEFD28 /* Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-ReceiverDemo/Pods-ReceiverDemo-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		32310565C7E21C1120BDDD58 /* Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Check Pods Manifest.lock";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
-			showEnvVarsInLog = 0;
-		};
-		34BE96D877C65145E7951D75 /* Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Check Pods Manifest.lock";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
-			showEnvVarsInLog = 0;
-		};
-		3D9B225BD699DD9D3E3783DD /* Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Embed Pods Frameworks";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-SenderDemo/Pods-SenderDemo-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		4025AE564DBFB183CA53A923 /* Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Embed Pods Frameworks";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-ReceiverDemo/Pods-ReceiverDemo-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		7E4A77AFF27B0E5465184209 /* Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Check Pods Manifest.lock";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
-			showEnvVarsInLog = 0;
-		};
-		82E3829DCB61E29D4B984C4F /* Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Copy Pods Resources";
+			name = "[CP] Copy Pods Resources";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -974,14 +854,14 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-SenderDemo/Pods-SenderDemo-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		9AC6E46B330C620FAB6621E4 /* Copy Pods Resources */ = {
+		29F4946D30704ABCEAD9DA22 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Copy Pods Resources";
+			name = "[CP] Copy Pods Resources";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -989,14 +869,119 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-ReceiverDemoSwift/Pods-ReceiverDemoSwift-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		A891777DE50BB01821DC55E8 /* Embed Pods Frameworks */ = {
+		36278AF8AB494B5291DEBF73 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Embed Pods Frameworks";
+			name = "[CP] Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		3B628DE034011539408FDD07 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-SenderDemo/Pods-SenderDemo-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		884395904B9A828AD2F8664B /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-ReceiverDemoSwift/Pods-ReceiverDemoSwift-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		A997E6273B854D3BA550C0D9 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		AFC605485982ED3785CAA667 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-ReceiverDemo/Pods-ReceiverDemo-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		BFA144B635D937E26209A8F7 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-ReceiverDemo/Pods-ReceiverDemo-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		DAD2C47D044A830C1DAF082E /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Tests/Pods-Tests-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		DBEE9C72636742AC90485FCE /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1018,19 +1003,34 @@
 			shellPath = /bin/sh;
 			shellScript = "\"${SRCROOT}/Tests/BuildScripts/specta-focus-check.sh\"";
 		};
-		F7AECAC5E12B21557769080B /* Embed Pods Frameworks */ = {
+		EA622D12052DB0D9D115BA41 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Embed Pods Frameworks";
+			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-ReceiverDemoSwift/Pods-ReceiverDemoSwift-frameworks.sh\"\n";
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		F88B971AF55760DF339BFF53 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -1219,7 +1219,7 @@
 		};
 		6003F5C0195388D20070C39A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 57D5F02E049D7887B4F4ACDF /* Pods-ReceiverDemo.debug.xcconfig */;
+			baseConfigurationReference = 592B45ECC86F96F2EC4E064B /* Pods-ReceiverDemo.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
@@ -1237,7 +1237,7 @@
 		};
 		6003F5C1195388D20070C39A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = BB75E70100C0775F382CD22F /* Pods-ReceiverDemo.release.xcconfig */;
+			baseConfigurationReference = 38C242B13D70274A4052BF29 /* Pods-ReceiverDemo.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
@@ -1255,7 +1255,7 @@
 		};
 		6003F5C3195388D20070C39A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 2AE3E05821FBC0C05F248E61 /* Pods-Tests.debug.xcconfig */;
+			baseConfigurationReference = 5FD0C3709C171E9583FCA4B0 /* Pods-Tests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
@@ -1270,7 +1270,7 @@
 		};
 		6003F5C4195388D20070C39A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = B3CB044233E227F87FCF2C46 /* Pods-Tests.release.xcconfig */;
+			baseConfigurationReference = 578651A2E783C4C2A9BD41AE /* Pods-Tests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
@@ -1285,7 +1285,7 @@
 		};
 		62335DF21B57003400E3818C /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = FBD5C3C0EA400B61BE35A3E4 /* Pods-ReceiverDemoSwift.debug.xcconfig */;
+			baseConfigurationReference = ABBF002169DAC24E56B80100 /* Pods-ReceiverDemoSwift.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
@@ -1311,7 +1311,7 @@
 		};
 		62335DF31B57003400E3818C /* Test */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = FB774EA6D84A50233F032ADC /* Pods-ReceiverDemoSwift.test.xcconfig */;
+			baseConfigurationReference = 61CCA9DC9B40CF38E6FF673E /* Pods-ReceiverDemoSwift.test.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
@@ -1333,7 +1333,7 @@
 		};
 		62335DF41B57003400E3818C /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 59C6806DC6FB049E0A3371C7 /* Pods-ReceiverDemoSwift.release.xcconfig */;
+			baseConfigurationReference = 7EA840098917BE391CCC70A3 /* Pods-ReceiverDemoSwift.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
@@ -1395,7 +1395,7 @@
 		};
 		DEA2AD621A4A8B0100F32289 /* Test */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 14A1857A6611A826E51F612A /* Pods-ReceiverDemo.test.xcconfig */;
+			baseConfigurationReference = 8B39E6D8A0A13F29A011AD50 /* Pods-ReceiverDemo.test.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
@@ -1414,7 +1414,7 @@
 		};
 		DEA2AD631A4A8B0100F32289 /* Test */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 6B9E60301031FFD1833ECA7A /* Pods-SenderDemo.test.xcconfig */;
+			baseConfigurationReference = 61496AE0E4E7CC07D76C8402 /* Pods-SenderDemo.test.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
@@ -1437,7 +1437,7 @@
 		};
 		DEA2AD641A4A8B0100F32289 /* Test */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = BBE7E5A25C1B0E9637BE745A /* Pods-Tests.test.xcconfig */;
+			baseConfigurationReference = 209B78B65FD39733D22E6684 /* Pods-Tests.test.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
@@ -1452,7 +1452,7 @@
 		};
 		DEDB14AE1A3F944E00A837F8 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = B915356798E84DC8F8A0A3CB /* Pods-SenderDemo.debug.xcconfig */;
+			baseConfigurationReference = BD3690E1AFBEEBE817A4D9AE /* Pods-SenderDemo.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
@@ -1475,7 +1475,7 @@
 		};
 		DEDB14AF1A3F944E00A837F8 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = A7644D9D2D35BA2869AD63FA /* Pods-SenderDemo.release.xcconfig */;
+			baseConfigurationReference = F6318D3E0D685F995698A23C /* Pods-SenderDemo.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;

--- a/DeepLinkKit.xcodeproj/project.pbxproj
+++ b/DeepLinkKit.xcodeproj/project.pbxproj
@@ -27,6 +27,10 @@
 		62EE96F71B570B13003D7564 /* DPLProduct.m in Sources */ = {isa = PBXBuildFile; fileRef = DE87B1F01A5DF49F00204A35 /* DPLProduct.m */; };
 		62EE96F81B570B16003D7564 /* DPLProductTableViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = DEAD327A19E079D3003C8D65 /* DPLProductTableViewController.m */; };
 		67C46D94DC68E22D70018D4A /* Pods_SenderDemo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 26835292B4AF23266C39DDA9 /* Pods_SenderDemo.framework */; };
+		70B73A051E30FE3D00F1DC10 /* DPLInventoryRouteHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 70B73A041E30FE3D00F1DC10 /* DPLInventoryRouteHandler.m */; };
+		70B73A081E31077800F1DC10 /* DPLInventoryTableViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 70B73A071E31077800F1DC10 /* DPLInventoryTableViewController.m */; };
+		70B73A0B1E31221C00F1DC10 /* DPLInventoryTableViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 70B73A071E31077800F1DC10 /* DPLInventoryTableViewController.m */; };
+		70B73A0C1E31233200F1DC10 /* DPLInventoryRouteHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70B73A091E3121F100F1DC10 /* DPLInventoryRouteHandler.swift */; };
 		885BF817236F484E7F5F73E2 /* Pods_ReceiverDemo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AF5DF65B06CA8F8FF3D9C377 /* Pods_ReceiverDemo.framework */; };
 		C4DC1B03379071F87259E123 /* Pods_ReceiverDemoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 67EA2BDC55F6B8A61FDF5848 /* Pods_ReceiverDemoSwift.framework */; };
 		DE025EB11A5F0D37007C4F3A /* DPLProductDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = DE025EB01A5F0D37007C4F3A /* DPLProductDataSource.m */; };
@@ -99,6 +103,11 @@
 		62EE96F11B57011D003D7564 /* ReceiverDemoSwift-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "ReceiverDemoSwift-Bridging-Header.h"; sourceTree = "<group>"; };
 		62EE96F31B570891003D7564 /* DPLProductRouteHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DPLProductRouteHandler.swift; sourceTree = "<group>"; };
 		67EA2BDC55F6B8A61FDF5848 /* Pods_ReceiverDemoSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ReceiverDemoSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		70B73A031E30FE3D00F1DC10 /* DPLInventoryRouteHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DPLInventoryRouteHandler.h; sourceTree = "<group>"; };
+		70B73A041E30FE3D00F1DC10 /* DPLInventoryRouteHandler.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DPLInventoryRouteHandler.m; sourceTree = "<group>"; };
+		70B73A061E31077800F1DC10 /* DPLInventoryTableViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DPLInventoryTableViewController.h; sourceTree = "<group>"; };
+		70B73A071E31077800F1DC10 /* DPLInventoryTableViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DPLInventoryTableViewController.m; sourceTree = "<group>"; };
+		70B73A091E3121F100F1DC10 /* DPLInventoryRouteHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DPLInventoryRouteHandler.swift; sourceTree = "<group>"; };
 		7EA840098917BE391CCC70A3 /* Pods-ReceiverDemoSwift.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ReceiverDemoSwift.release.xcconfig"; path = "Pods/Target Support Files/Pods-ReceiverDemoSwift/Pods-ReceiverDemoSwift.release.xcconfig"; sourceTree = "<group>"; };
 		83D34C3B1B03ECAD00BA6EF1 /* DPLMatchResult.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DPLMatchResult.h; sourceTree = "<group>"; };
 		83D34C3C1B03ECAD00BA6EF1 /* DPLMatchResult.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = DPLMatchResult.m; sourceTree = "<group>"; };
@@ -343,6 +352,7 @@
 			children = (
 				62EE96F31B570891003D7564 /* DPLProductRouteHandler.swift */,
 				62891E8A1B57FE5A00C2AF4F /* DPLMessageRouteHandler.swift */,
+				70B73A091E3121F100F1DC10 /* DPLInventoryRouteHandler.swift */,
 			);
 			path = RouteHandlers;
 			sourceTree = "<group>";
@@ -524,6 +534,8 @@
 			children = (
 				DE87B1EC1A5DEFD400204A35 /* DPLProductRouteHandler.h */,
 				DE87B1ED1A5DEFD400204A35 /* DPLProductRouteHandler.m */,
+				70B73A031E30FE3D00F1DC10 /* DPLInventoryRouteHandler.h */,
+				70B73A041E30FE3D00F1DC10 /* DPLInventoryRouteHandler.m */,
 			);
 			path = RouteHandlers;
 			sourceTree = "<group>";
@@ -542,6 +554,8 @@
 			children = (
 				DEAD327919E079D3003C8D65 /* DPLProductTableViewController.h */,
 				DEAD327A19E079D3003C8D65 /* DPLProductTableViewController.m */,
+				70B73A061E31077800F1DC10 /* DPLInventoryTableViewController.h */,
+				70B73A071E31077800F1DC10 /* DPLInventoryTableViewController.m */,
 			);
 			path = ProductList;
 			sourceTree = "<group>";
@@ -767,6 +781,9 @@
 				LastUpgradeCheck = 0700;
 				ORGANIZATIONNAME = "Button, Inc.";
 				TargetAttributes = {
+					6003F589195388D20070C39A = {
+						LastSwiftMigration = 0820;
+					};
 					6003F5AD195388D20070C39A = {
 						TestTargetID = 6003F589195388D20070C39A;
 					};
@@ -1040,7 +1057,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				70B73A051E30FE3D00F1DC10 /* DPLInventoryRouteHandler.m in Sources */,
 				DE87B1F51A5E193100204A35 /* DPLProductDetailViewController.m in Sources */,
+				70B73A081E31077800F1DC10 /* DPLInventoryTableViewController.m in Sources */,
 				DEAD328A19E079D3003C8D65 /* DPLProductTableViewController.m in Sources */,
 				DE025EB11A5F0D37007C4F3A /* DPLProductDataSource.m in Sources */,
 				DE87B1F11A5DF49F00204A35 /* DPLProduct.m in Sources */,
@@ -1078,9 +1097,11 @@
 				62EE96F61B570B10003D7564 /* DPLProductDataSource.m in Sources */,
 				62EE96F51B570AF4003D7564 /* DPLProductDetailViewController.m in Sources */,
 				62335E031B57007F00E3818C /* DPLReceiverSwiftAppDelegate.swift in Sources */,
+				70B73A0B1E31221C00F1DC10 /* DPLInventoryTableViewController.m in Sources */,
 				62891E8B1B57FE5A00C2AF4F /* DPLMessageRouteHandler.swift in Sources */,
 				62EE96F81B570B16003D7564 /* DPLProductTableViewController.m in Sources */,
 				62EE96F71B570B13003D7564 /* DPLProduct.m in Sources */,
+				70B73A0C1E31233200F1DC10 /* DPLInventoryRouteHandler.swift in Sources */,
 				62EE96F41B570891003D7564 /* DPLProductRouteHandler.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1224,12 +1245,16 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
 				CLANG_ENABLE_CODE_COVERAGE = NO;
+				CLANG_ENABLE_MODULES = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "SampleApps/ReceiverDemo/SupportingFiles/ReceiverDemo-Prefix.pch";
 				INFOPLIST_FILE = "SampleApps/ReceiverDemo/SupportingFiles/ReceiverDemo-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.usebutton.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = 1;
 				WRAPPER_EXTENSION = app;
 			};
@@ -1242,12 +1267,15 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
 				CLANG_ENABLE_CODE_COVERAGE = NO;
+				CLANG_ENABLE_MODULES = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "SampleApps/ReceiverDemo/SupportingFiles/ReceiverDemo-Prefix.pch";
 				INFOPLIST_FILE = "SampleApps/ReceiverDemo/SupportingFiles/ReceiverDemo-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.usebutton.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = 1;
 				WRAPPER_EXTENSION = app;
 			};
@@ -1305,6 +1333,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "SampleApps/ReceiverDemoSwift/ReceiverDemoSwift-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 2.3;
 				TARGETED_DEVICE_FAMILY = 1;
 			};
 			name = Debug;
@@ -1327,6 +1356,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.usebutton.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "SampleApps/ReceiverDemoSwift/ReceiverDemoSwift-Bridging-Header.h";
+				SWIFT_VERSION = 2.3;
 				TARGETED_DEVICE_FAMILY = 1;
 			};
 			name = Test;
@@ -1349,6 +1379,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.usebutton.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "SampleApps/ReceiverDemoSwift/ReceiverDemoSwift-Bridging-Header.h";
+				SWIFT_VERSION = 2.3;
 				TARGETED_DEVICE_FAMILY = 1;
 			};
 			name = Release;
@@ -1400,13 +1431,17 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
 				CLANG_ENABLE_CODE_COVERAGE = NO;
+				CLANG_ENABLE_MODULES = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "SampleApps/ReceiverDemo/SupportingFiles/ReceiverDemo-Prefix.pch";
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				INFOPLIST_FILE = "SampleApps/ReceiverDemo/SupportingFiles/ReceiverDemo-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.usebutton.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = 1;
 				WRAPPER_EXTENSION = app;
 			};

--- a/DeepLinkKit/RouteHandler/DPLRouteHandler.h
+++ b/DeepLinkKit/RouteHandler/DPLRouteHandler.h
@@ -33,6 +33,12 @@
  */
 - (BOOL)preferModalPresentation;
 
+/**
+ If you prefer to present the target view controller asynchronously using 
+ `targetViewControllerWithCompletionHandler:`, override this method and return YES. The default is NO.
+ */
+- (BOOL)preferAsynchronous;
+
 
 /**
  The view controller that will be presented as a result of the deep link.
@@ -40,6 +46,15 @@
  @note Subclasses MUST override this method.
  */
 - (UIViewController <DPLTargetViewController> *)targetViewController;
+
+/**
+ The view controller that will be presented as a result of the deep link.
+ @param completionHandler A block that will be called when the view controller is ready to be returned.
+ @note This method will ONLY be called if subclasses have overridden the method `preferAsynchronous` and
+ it returns YES.  In this case, the method `targetViewController` will not be called.
+ */
+- (void)targetViewControllerWithCompletion:(void(^)(UIViewController <DPLTargetViewController>*))completionHandler;
+
 
 
 /**

--- a/DeepLinkKit/RouteHandler/DPLRouteHandler.m
+++ b/DeepLinkKit/RouteHandler/DPLRouteHandler.m
@@ -12,9 +12,16 @@
     return NO;
 }
 
+- (BOOL)preferAsynchronous {
+    return NO;
+}
 
 - (UIViewController <DPLTargetViewController> *)targetViewController {
     return nil;
+}
+
+- (void)targetViewControllerWithCompletion:(void(^)(UIViewController <DPLTargetViewController>*))completionHandler {
+    completionHandler(nil);
 }
 
 

--- a/Podfile
+++ b/Podfile
@@ -2,19 +2,19 @@ xcodeproj 'DeepLinkKit.xcodeproj', 'Test' => :debug
 inhibit_all_warnings!
 use_frameworks!
 
-target 'SenderDemo', :exclusive => true do
-    pod 'DeepLinkKit', :path => '.'
+target 'SenderDemo' do
+    pod 'DeepLinkKit'
 end
 
-target 'ReceiverDemo', :exclusive => true do
-    pod 'DeepLinkKit', :path => '.'
+target 'ReceiverDemo' do
+    pod 'DeepLinkKit'
 end
 
-target 'ReceiverDemoSwift', :exclusive => true do
-    pod 'DeepLinkKit', :path => '.'
+target 'ReceiverDemoSwift' do
+    pod 'DeepLinkKit'
 end
 
-target 'Tests', :exclusive => true do
+target 'Tests' do
     pod 'Specta'
     pod 'Expecta'
     pod 'OCMock'

--- a/Podfile
+++ b/Podfile
@@ -3,15 +3,15 @@ inhibit_all_warnings!
 use_frameworks!
 
 target 'SenderDemo' do
-    pod 'DeepLinkKit'
+    pod 'DeepLinkKit', :path => '.'
 end
 
 target 'ReceiverDemo' do
-    pod 'DeepLinkKit'
+    pod 'DeepLinkKit', :path => '.'
 end
 
 target 'ReceiverDemoSwift' do
-    pod 'DeepLinkKit'
+    pod 'DeepLinkKit', :path => '.'
 end
 
 target 'Tests' do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -8,15 +8,11 @@ PODS:
   - Specta (1.0.5)
 
 DEPENDENCIES:
-  - DeepLinkKit (from `.`)
+  - DeepLinkKit
   - Expecta
   - KIF
   - OCMock
   - Specta
-
-EXTERNAL SOURCES:
-  DeepLinkKit:
-    :path: .
 
 SPEC CHECKSUMS:
   DeepLinkKit: 4c3a713b7ecc6c6e25ba56c87d0c728f6035a9ef
@@ -25,4 +21,6 @@ SPEC CHECKSUMS:
   OCMock: 18c9b7e67d4c2770e95bb77a9cc1ae0c91fe3835
   Specta: ac94d110b865115fe60ff2c6d7281053c6f8e8a2
 
-COCOAPODS: 0.39.0
+PODFILE CHECKSUM: cecee7c3c8bb0ef49d3e2de3643a641518c47fd1
+
+COCOAPODS: 1.1.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,26 +1,30 @@
 PODS:
   - DeepLinkKit (1.2.1)
   - Expecta (1.0.5)
-  - KIF (3.4.1):
-    - KIF/Core (= 3.4.1)
-  - KIF/Core (3.4.1)
-  - OCMock (3.2.2)
+  - KIF (3.5.1):
+    - KIF/Core (= 3.5.1)
+  - KIF/Core (3.5.1)
+  - OCMock (3.4)
   - Specta (1.0.5)
 
 DEPENDENCIES:
-  - DeepLinkKit
+  - DeepLinkKit (from `.`)
   - Expecta
   - KIF
   - OCMock
   - Specta
 
+EXTERNAL SOURCES:
+  DeepLinkKit:
+    :path: .
+
 SPEC CHECKSUMS:
   DeepLinkKit: 4c3a713b7ecc6c6e25ba56c87d0c728f6035a9ef
   Expecta: e1c022fcd33910b6be89c291d2775b3fe27a89fe
-  KIF: 2275c6d59c77e5e56f660f006b99d73780130540
-  OCMock: 18c9b7e67d4c2770e95bb77a9cc1ae0c91fe3835
+  KIF: 082eb65279e51c3092923802849eb796a04982ab
+  OCMock: 35ae71d6a8fcc1b59434d561d1520b9dd4f15765
   Specta: ac94d110b865115fe60ff2c6d7281053c6f8e8a2
 
-PODFILE CHECKSUM: cecee7c3c8bb0ef49d3e2de3643a641518c47fd1
+PODFILE CHECKSUM: f856d9093736cda8b86782d4d84899602663e1c5
 
 COCOAPODS: 1.1.1

--- a/SampleApps/ReceiverDemo/Base.lproj/Main.storyboard
+++ b/SampleApps/ReceiverDemo/Base.lproj/Main.storyboard
@@ -1,8 +1,12 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="7706" systemVersion="14E46" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="Mxc-im-9AM">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11762" systemVersion="16C67" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES" initialViewController="Mxc-im-9AM">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7703"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--View Controller-->
@@ -14,47 +18,69 @@
                         <viewControllerLayoutGuide type="bottom" id="uzJ-gE-FTl"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="ZeH-PS-M02">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="3yC-nb-lYe">
-                                <rect key="frame" x="30" y="134" width="260" height="300"/>
+                                <rect key="frame" x="30" y="184" width="315" height="300"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Afi-TK-8He">
-                                        <rect key="frame" x="0.0" y="180" width="260" height="120"/>
-                                        <color key="backgroundColor" red="0.90196079015731812" green="0.90196079015731812" blue="0.90196079015731812" alpha="1" colorSpace="calibratedRGB"/>
+                                        <rect key="frame" x="0.0" y="110" width="315" height="80"/>
+                                        <color key="backgroundColor" red="0.90196079015731812" green="0.90196079015731812" blue="0.90196079015731812" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <constraints>
-                                            <constraint firstAttribute="height" constant="120" id="TYG-2W-k7u"/>
+                                            <constraint firstAttribute="height" constant="80" id="TYG-2W-k7u"/>
                                         </constraints>
                                         <fontDescription key="fontDescription" name="AvenirNext-Bold" family="Avenir Next" pointSize="24"/>
                                         <state key="normal" title="Shop Wine">
-                                            <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
-                                            <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                            <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                            <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         </state>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="68W-jO-vLL">
-                                        <rect key="frame" x="0.0" y="0.0" width="260" height="120"/>
-                                        <color key="backgroundColor" red="0.0" green="0.50196081399917603" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="315" height="80"/>
+                                        <color key="backgroundColor" red="0.0" green="0.50196081399917603" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <constraints>
-                                            <constraint firstAttribute="height" constant="120" id="pgE-3J-89h"/>
+                                            <constraint firstAttribute="height" constant="80" id="pgE-3J-89h"/>
                                         </constraints>
                                         <fontDescription key="fontDescription" name="AvenirNext-Bold" family="Avenir Next" pointSize="24"/>
                                         <state key="normal" title="Shop Beer">
-                                            <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
-                                            <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                            <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                            <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         </state>
                                         <connections>
                                             <segue destination="pmT-Ue-yiK" kind="push" id="WnK-hq-fwO"/>
                                         </connections>
                                     </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ptO-P3-fYo" userLabel="Inventory">
+                                        <rect key="frame" x="0.0" y="220" width="315" height="80"/>
+                                        <color key="backgroundColor" red="0.0" green="0.50196081400000003" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="80" id="VlJ-AQ-o6r"/>
+                                        </constraints>
+                                        <fontDescription key="fontDescription" name="AvenirNext-Bold" family="Avenir Next" pointSize="24"/>
+                                        <state key="normal" title="Inventory">
+                                            <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                            <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        </state>
+                                        <connections>
+                                            <segue destination="0p4-ye-gd1" kind="push" id="Zpq-jh-6na"/>
+                                        </connections>
+                                    </button>
                                 </subviews>
-                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
+                                    <constraint firstItem="68W-jO-vLL" firstAttribute="leading" secondItem="3yC-nb-lYe" secondAttribute="leading" id="0fQ-3U-NkO"/>
                                     <constraint firstItem="Afi-TK-8He" firstAttribute="height" secondItem="68W-jO-vLL" secondAttribute="height" id="1hy-lM-F7R"/>
-                                    <constraint firstAttribute="bottom" secondItem="Afi-TK-8He" secondAttribute="bottom" id="7bZ-Hg-Lqf"/>
-                                    <constraint firstItem="Afi-TK-8He" firstAttribute="top" secondItem="68W-jO-vLL" secondAttribute="bottom" constant="60" id="AiW-Mg-GAx"/>
+                                    <constraint firstItem="ptO-P3-fYo" firstAttribute="top" secondItem="Afi-TK-8He" secondAttribute="bottom" constant="30" id="2jT-sj-7k4"/>
+                                    <constraint firstItem="Afi-TK-8He" firstAttribute="top" secondItem="68W-jO-vLL" secondAttribute="bottom" constant="30" id="AiW-Mg-GAx"/>
                                     <constraint firstItem="Afi-TK-8He" firstAttribute="leading" secondItem="3yC-nb-lYe" secondAttribute="leading" id="DAX-O6-pa1"/>
+                                    <constraint firstAttribute="trailing" secondItem="ptO-P3-fYo" secondAttribute="trailing" id="NHs-Dm-wma"/>
                                     <constraint firstItem="68W-jO-vLL" firstAttribute="top" secondItem="3yC-nb-lYe" secondAttribute="top" id="NUS-d0-jWt"/>
+                                    <constraint firstItem="ptO-P3-fYo" firstAttribute="width" secondItem="68W-jO-vLL" secondAttribute="width" id="W6J-e6-gJM"/>
+                                    <constraint firstItem="ptO-P3-fYo" firstAttribute="leading" secondItem="3yC-nb-lYe" secondAttribute="leading" id="b58-ok-qfN"/>
+                                    <constraint firstAttribute="trailing" secondItem="68W-jO-vLL" secondAttribute="trailing" id="dfL-lz-4Ez"/>
+                                    <constraint firstAttribute="bottom" secondItem="ptO-P3-fYo" secondAttribute="bottom" id="dgT-fm-3xh"/>
+                                    <constraint firstItem="ptO-P3-fYo" firstAttribute="height" secondItem="68W-jO-vLL" secondAttribute="height" id="hO3-Ld-mxk"/>
                                     <constraint firstItem="68W-jO-vLL" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="3yC-nb-lYe" secondAttribute="leading" id="j3T-Xj-MEz"/>
                                     <constraint firstAttribute="trailing" secondItem="Afi-TK-8He" secondAttribute="trailing" id="lKC-ud-VOl"/>
                                     <constraint firstItem="Afi-TK-8He" firstAttribute="width" secondItem="68W-jO-vLL" secondAttribute="width" id="loo-Eu-Jsr"/>
@@ -63,7 +89,7 @@
                                 </constraints>
                             </view>
                         </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstAttribute="centerY" secondItem="3yC-nb-lYe" secondAttribute="centerY" id="Gas-P2-Xfw"/>
                             <constraint firstAttribute="trailing" secondItem="3yC-nb-lYe" secondAttribute="trailing" constant="30" id="nxW-Ih-2yh"/>
@@ -81,25 +107,29 @@
             <objects>
                 <tableViewController storyboardIdentifier="beers" id="pmT-Ue-yiK" customClass="DPLProductTableViewController" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="22" sectionFooterHeight="22" id="5gY-5b-CWV">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <prototypes>
                             <tableViewCell contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="product-cell" textLabel="4gq-4c-TFd" detailTextLabel="3qi-7w-OX8" style="IBUITableViewCellStyleValue1" id="kji-20-QMf">
+                                <rect key="frame" x="0.0" y="22" width="375" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="kji-20-QMf" id="1FJ-60-XEt">
+                                    <rect key="frame" x="0.0" y="0.0" width="342" height="43"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Beer" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="4gq-4c-TFd">
+                                            <rect key="frame" x="15" y="12" width="34" height="20"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="16"/>
-                                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="$0.00" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="3qi-7w-OX8">
+                                            <rect key="frame" x="297" y="12" width="43" height="20"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="16"/>
-                                            <color key="textColor" red="0.55686274509803924" green="0.55686274509803924" blue="0.57647058823529407" alpha="1" colorSpace="calibratedRGB"/>
+                                            <color key="textColor" red="0.55686274509803924" green="0.55686274509803924" blue="0.57647058823529407" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                     </subviews>
@@ -118,7 +148,52 @@
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="TQX-gt-yb7" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1170" y="-187"/>
+            <point key="canvasLocation" x="1278" y="-191"/>
+        </scene>
+        <!--Inventory-->
+        <scene sceneID="ymv-Qv-kNy">
+            <objects>
+                <tableViewController storyboardIdentifier="inventory" id="0p4-ye-gd1" userLabel="Inventory" customClass="DPLInventoryTableViewController" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" allowsSelection="NO" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" id="jAV-Mg-wfT">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <prototypes>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="product-cell" textLabel="hq5-fs-lDq" detailTextLabel="H1b-40-YE1" style="IBUITableViewCellStyleValue1" id="xrU-zi-lc7" userLabel="product-cell">
+                                <rect key="frame" x="0.0" y="28" width="375" height="44"/>
+                                <autoresizingMask key="autoresizingMask"/>
+                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="xrU-zi-lc7" id="jnp-Yw-dQI">
+                                    <rect key="frame" x="0.0" y="0.0" width="375" height="43"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                    <subviews>
+                                        <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="hq5-fs-lDq" userLabel="Product">
+                                            <rect key="frame" x="15" y="11" width="34" height="21"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                            <nil key="textColor"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                        <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Detail" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="H1b-40-YE1" userLabel="Count">
+                                            <rect key="frame" x="316" y="11" width="44" height="21"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                            <nil key="textColor"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                    </subviews>
+                                </tableViewCellContentView>
+                            </tableViewCell>
+                        </prototypes>
+                        <connections>
+                            <outlet property="dataSource" destination="0p4-ye-gd1" id="F8h-CW-tlI"/>
+                            <outlet property="delegate" destination="0p4-ye-gd1" id="3M9-gb-eT4"/>
+                        </connections>
+                    </tableView>
+                    <navigationItem key="navigationItem" title="Inventory" id="wye-bM-KBY" userLabel="Inventory"/>
+                </tableViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="owA-kV-dy3" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1278" y="652"/>
         </scene>
         <!--Detail-->
         <scene sceneID="SKX-tZ-GZJ">
@@ -129,35 +204,35 @@
                         <viewControllerLayoutGuide type="bottom" id="8Us-OE-IJB"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="NaF-X2-uK3">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Beer Name" textAlignment="center" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="270" translatesAutoresizingMaskIntoConstraints="NO" id="ePO-uQ-SAF">
-                                <rect key="frame" x="25" y="271" width="269" height="27"/>
+                                <rect key="frame" x="25" y="320" width="325" height="27"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="22"/>
-                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="$0.00" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="200" translatesAutoresizingMaskIntoConstraints="NO" id="hTB-1e-KBy">
-                                <rect key="frame" x="139" y="305" width="43" height="21"/>
+                                <rect key="frame" x="166" y="354" width="45" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="gwo-qw-10k">
-                                <rect key="frame" x="0.0" y="508" width="320" height="60"/>
-                                <color key="backgroundColor" red="0.0" green="0.50196081399917603" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                <rect key="frame" x="0.0" y="607" width="375" height="60"/>
+                                <color key="backgroundColor" red="0.0" green="0.50196081399917603" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="60" id="TIu-Ro-EB7"/>
                                 </constraints>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="19"/>
                                 <state key="normal" title="Buy">
-                                    <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
-                                    <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                    <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                    <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 </state>
                             </button>
                         </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstItem="8Us-OE-IJB" firstAttribute="top" secondItem="gwo-qw-10k" secondAttribute="bottom" id="7IR-gD-fRt"/>
                             <constraint firstAttribute="centerY" secondItem="ePO-uQ-SAF" secondAttribute="centerY" id="Emn-jL-IZ0"/>
@@ -177,7 +252,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="pa2-RH-efY" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1550" y="-187"/>
+            <point key="canvasLocation" x="1755" y="-190"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="SJi-LL-6oV">
@@ -195,12 +270,12 @@
                 </navigationController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="oh6-dh-xZ8" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="414" y="-187"/>
+            <point key="canvasLocation" x="189" y="-189"/>
         </scene>
     </scenes>
     <simulatedMetricsContainer key="defaultSimulatedMetrics">
         <simulatedStatusBarMetrics key="statusBar"/>
         <simulatedOrientationMetrics key="orientation"/>
-        <simulatedScreenMetrics key="destination" type="retina4"/>
+        <simulatedScreenMetrics key="destination" type="retina4_7.fullscreen"/>
     </simulatedMetricsContainer>
 </document>

--- a/SampleApps/ReceiverDemo/DPLReceiverAppDelegate.m
+++ b/SampleApps/ReceiverDemo/DPLReceiverAppDelegate.m
@@ -1,5 +1,6 @@
 #import "DPLReceiverAppDelegate.h"
 #import "DPLProductRouteHandler.h"
+#import "DPLInventoryRouteHandler.h"
 
 @import DeepLinkKit;
 
@@ -17,8 +18,11 @@
     self.router = [[DPLDeepLinkRouter alloc] init];
    
     
-    // Route registration.
+    // Route registration using the synchronous router
     self.router[@"/product/:sku"] = [DPLProductRouteHandler class];
+    
+    // Route registration using the asynchronous route
+    self.router[@"/inventory"] = [DPLInventoryRouteHandler class];
     
     self.router[@"/say/:title/:message"] = ^(DPLDeepLink *link) {
         [[[UIAlertView alloc] initWithTitle:link[@"title"]

--- a/SampleApps/ReceiverDemo/Images.xcassets/AppIcon.appiconset/Contents.json
+++ b/SampleApps/ReceiverDemo/Images.xcassets/AppIcon.appiconset/Contents.json
@@ -2,6 +2,16 @@
   "images" : [
     {
       "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
       "size" : "29x29",
       "scale" : "2x"
     },
@@ -29,6 +39,16 @@
       "idiom" : "iphone",
       "size" : "60x60",
       "scale" : "3x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "20x20",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "20x20",
+      "scale" : "2x"
     },
     {
       "idiom" : "ipad",

--- a/SampleApps/ReceiverDemo/ProductData/DPLProduct.h
+++ b/SampleApps/ReceiverDemo/ProductData/DPLProduct.h
@@ -5,7 +5,8 @@
 @property (nonatomic, copy,   readonly) NSString *name;
 @property (nonatomic, assign, readonly) NSInteger price;
 @property (nonatomic, copy,   readonly) NSString  *sku;
+@property (nonatomic, assign, readonly) NSInteger count;
 
-+ (instancetype)productWithName:(NSString *)name price:(NSInteger)price sku:(NSString *)sku;
++ (instancetype)productWithName:(NSString *)name price:(NSInteger)price sku:(NSString *)sku count:(NSInteger)count;
 
 @end

--- a/SampleApps/ReceiverDemo/ProductData/DPLProduct.m
+++ b/SampleApps/ReceiverDemo/ProductData/DPLProduct.m
@@ -2,18 +2,19 @@
 
 @implementation DPLProduct
 
-+ (instancetype)productWithName:(NSString *)name price:(NSInteger)price sku:(NSString *)sku {
-    DPLProduct *product = [[self alloc] initWithName:name price:price sku:sku];
++ (instancetype)productWithName:(NSString *)name price:(NSInteger)price sku:(NSString *)sku  count:(NSInteger)count{
+    DPLProduct *product = [[self alloc] initWithName:name price:price sku:sku count:count];
     return product;
 }
 
 
-- (instancetype)initWithName:(NSString *)name price:(NSInteger)price sku:(NSString *)sku {
+- (instancetype)initWithName:(NSString *)name price:(NSInteger)price sku:(NSString *)sku  count:(NSInteger)count{
     self   = [super init];
     
     _name  = name;
     _price = price;
     _sku   = sku;
+    _count = count;
     
     return self;
 }

--- a/SampleApps/ReceiverDemo/ProductData/DPLProductDataSource.h
+++ b/SampleApps/ReceiverDemo/ProductData/DPLProductDataSource.h
@@ -2,7 +2,16 @@
 
 @class DPLProduct;
 
+typedef NS_ENUM(NSInteger, DPLProductDataSourceType) {
+    DPLProductDataSourceTypePrice,
+    DPLProductDataSourceTypeCount
+};
+
 @interface DPLProductDataSource : NSObject <UITableViewDataSource>
+
+- (instancetype)initWithSourceType:(DPLProductDataSourceType)sourceType;
+
+@property (nonatomic, assign, readonly) DPLProductDataSourceType sourceType;
 
 - (DPLProduct *)productWithSku:(NSString *)sku;
 

--- a/SampleApps/ReceiverDemo/ProductData/DPLProductDataSource.m
+++ b/SampleApps/ReceiverDemo/ProductData/DPLProductDataSource.m
@@ -10,19 +10,21 @@
 
 @implementation DPLProductDataSource
 
-- (instancetype)init {
+- (instancetype)initWithSourceType:(DPLProductDataSourceType)sourceType {
     self = [super init];
     if (self) {
-        _products = @[[DPLProduct productWithName:@"Southern Tier Pumking Ale"         price:799  sku:@"93127"],
-                      [DPLProduct productWithName:@"Samuel Adams Winter Lager"         price:1399 sku:@"99542"],
-                      [DPLProduct productWithName:@"Sierra Nevada Celebration Ale"     price:799  sku:@"93612"],
-                      [DPLProduct productWithName:@"Anchor Christmas Ale"              price:1199 sku:@"93522"],
-                      [DPLProduct productWithName:@"Woodchuck Pumpkin Private Reserve" price:1199 sku:@"93632"],
-                      [DPLProduct productWithName:@"Lagunitas Brown Shugga'"           price:1099 sku:@"93742"],
-                      [DPLProduct productWithName:@"Dogfish Head Festina Peche"        price:899  sku:@"93642"],
-                      [DPLProduct productWithName:@"Shiner Oktoberfest"                price:899  sku:@"93598"],
-                      [DPLProduct productWithName:@"Magic Hat Variety Winterland"      price:1299 sku:@"93312"],
-                      [DPLProduct productWithName:@"Blue Moon Winter Abbey Ale"        price:849  sku:@"93648"]];
+        _sourceType = sourceType;
+        
+        _products = @[[DPLProduct productWithName:@"Southern Tier Pumking Ale"         price:799  sku:@"93127" count:10],
+                      [DPLProduct productWithName:@"Samuel Adams Winter Lager"         price:1399 sku:@"99542" count:12],
+                      [DPLProduct productWithName:@"Sierra Nevada Celebration Ale"     price:799  sku:@"93612" count:8],
+                      [DPLProduct productWithName:@"Anchor Christmas Ale"              price:1199 sku:@"93522" count:0],
+                      [DPLProduct productWithName:@"Woodchuck Pumpkin Private Reserve" price:1199 sku:@"93632" count:6],
+                      [DPLProduct productWithName:@"Lagunitas Brown Shugga'"           price:1099 sku:@"93742" count:14],
+                      [DPLProduct productWithName:@"Dogfish Head Festina Peche"        price:899  sku:@"93642" count:18],
+                      [DPLProduct productWithName:@"Shiner Oktoberfest"                price:899  sku:@"93598" count:1],
+                      [DPLProduct productWithName:@"Magic Hat Variety Winterland"      price:1299 sku:@"93312" count:11],
+                      [DPLProduct productWithName:@"Blue Moon Winter Abbey Ale"        price:849  sku:@"93648" count:13]];
     }
     return self;
 }
@@ -48,11 +50,21 @@
 
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
     
+    
     UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"product-cell" forIndexPath:indexPath];
     DPLProduct *product   = self.products[indexPath.row];
     
-    cell.textLabel.text       = product.name;
-    cell.detailTextLabel.text = [@(product.price / 100.0) stringValue];
+    cell.textLabel.text = product.name;
+    
+    switch (_sourceType) {
+        case DPLProductDataSourceTypePrice:
+            cell.detailTextLabel.text = [@(product.price / 100.0) stringValue];
+            break;
+            
+        case DPLProductDataSourceTypeCount:
+            cell.detailTextLabel.text = [@(product.count) stringValue];
+            break;
+    }
     
     return cell;
 }

--- a/SampleApps/ReceiverDemo/ProductList/DPLInventoryTableViewController.h
+++ b/SampleApps/ReceiverDemo/ProductList/DPLInventoryTableViewController.h
@@ -1,0 +1,6 @@
+#import <UIKit/UIKit.h>
+#import <DeepLinkKit/DeepLinkKit.h>
+
+@interface DPLInventoryTableViewController : UITableViewController  <DPLTargetViewController>
+
+@end

--- a/SampleApps/ReceiverDemo/ProductList/DPLInventoryTableViewController.m
+++ b/SampleApps/ReceiverDemo/ProductList/DPLInventoryTableViewController.m
@@ -1,0 +1,29 @@
+#import "DPLInventoryTableViewController.h"
+#import "DPLProductDataSource.h"
+
+
+@interface DPLInventoryTableViewController ()
+
+@property (nonatomic, strong) DPLProductDataSource *dataSource;
+
+@end
+
+@implementation DPLInventoryTableViewController
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    
+    self.dataSource = [[DPLProductDataSource alloc] initWithSourceType:DPLProductDataSourceTypeCount];
+    self.tableView.dataSource = self.dataSource;
+}
+
+#pragma mark - DPLTargetViewController
+
+- (void)configureWithDeepLink:(DPLDeepLink *)deepLink {
+    //No Op
+}
+
+@end
+
+
+

--- a/SampleApps/ReceiverDemo/ProductList/DPLProductTableViewController.m
+++ b/SampleApps/ReceiverDemo/ProductList/DPLProductTableViewController.m
@@ -14,7 +14,7 @@
 - (void)viewDidLoad {
     [super viewDidLoad];
     
-    self.dataSource = [[DPLProductDataSource alloc] init];
+    self.dataSource = [[DPLProductDataSource alloc] initWithSourceType:DPLProductDataSourceTypePrice];
     self.tableView.dataSource = self.dataSource;
 }
 

--- a/SampleApps/ReceiverDemo/RouteHandlers/DPLInventoryRouteHandler.h
+++ b/SampleApps/ReceiverDemo/RouteHandlers/DPLInventoryRouteHandler.h
@@ -1,0 +1,8 @@
+#import <DeepLinkKit/DeepLinkKit.h>
+
+/**
+ An example of an asynchronous route handler
+ */
+@interface DPLInventoryRouteHandler : DPLRouteHandler
+
+@end

--- a/SampleApps/ReceiverDemo/RouteHandlers/DPLInventoryRouteHandler.m
+++ b/SampleApps/ReceiverDemo/RouteHandlers/DPLInventoryRouteHandler.m
@@ -1,0 +1,19 @@
+#import "DPLInventoryRouteHandler.h"
+
+@implementation DPLInventoryRouteHandler
+
+- (BOOL)preferAsynchronous {
+    return YES;
+}
+
+- (void)targetViewControllerWithCompletion:(void (^)(UIViewController<DPLTargetViewController> *))completionHandler {
+    UIStoryboard *storyboard = [UIApplication sharedApplication].keyWindow.rootViewController.storyboard;
+    
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(2 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        UIViewController<DPLTargetViewController> *vc = [storyboard instantiateViewControllerWithIdentifier:@"inventory"];
+        completionHandler(vc);
+    });
+
+}
+
+@end

--- a/SampleApps/ReceiverDemoSwift/DPLReceiverSwiftAppDelegate.swift
+++ b/SampleApps/ReceiverDemoSwift/DPLReceiverSwiftAppDelegate.swift
@@ -14,6 +14,9 @@ class DPLReceiverSwiftAppDelegate: UIResponder, UIApplicationDelegate {
         // Register a class to a route using the explicit registration call
         self.router.registerHandlerClass(DPLMessageRouteHandler.self, forRoute: "/say/:title/:message")
         
+        // Register a class to route using an asynchronous target view controller request
+        self.router["/inventory"] = DPLInventoryRouteHandler.self
+        
         return true
     }
     

--- a/SampleApps/ReceiverDemoSwift/ReceiverDemoSwift-Bridging-Header.h
+++ b/SampleApps/ReceiverDemoSwift/ReceiverDemoSwift-Bridging-Header.h
@@ -2,4 +2,5 @@
 #import "DPLProduct.h"
 #import "DPLProductDataSource.h"
 #import "DPLProductTableViewController.h"
+#import "DPLInventoryTableViewController.h"
 #import "DPLProductDetailViewController.h"

--- a/SampleApps/ReceiverDemoSwift/RouteHandlers/DPLInventoryRouteHandler.swift
+++ b/SampleApps/ReceiverDemoSwift/RouteHandlers/DPLInventoryRouteHandler.swift
@@ -1,0 +1,19 @@
+import UIKit
+
+public class DPLInventoryRouteHandler: DPLRouteHandler {
+    public override func preferAsynchronous() -> Bool {
+        return true
+    }
+    
+    public override func targetViewControllerWithCompletion(completionHandler: ((UIViewController!) -> Void)!) {
+        guard let storyboard = UIApplication.sharedApplication().keyWindow?.rootViewController?.storyboard else {
+            completionHandler(nil)
+            return
+        }
+        
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (Int64)(2 * NSEC_PER_SEC)), dispatch_get_main_queue()) {
+            let vc = storyboard.instantiateViewControllerWithIdentifier("inventory") as! DPLInventoryTableViewController
+            completionHandler(vc)
+        }
+    }
+}

--- a/SampleApps/SenderDemo/ActionData/DPLActionDataSource.m
+++ b/SampleApps/SenderDemo/ActionData/DPLActionDataSource.m
@@ -16,6 +16,7 @@
     if (self) {
         _actions = @[[self loadBeersAction],
                      [self loadOktoberfestAction],
+                     [self loadProductInventory],
                      [self logHelloWorldAction]];
     }
     return self;
@@ -64,6 +65,15 @@
     return action;
 }
 
+- (DPLDemoAction *)loadProductInventory {
+    DPLMutableDeepLink *link = [[DPLMutableDeepLink alloc] initWithString:@"dpl://dpl.com"];
+    link.path = @"/inventory";
+    
+    DPLDemoAction *action = [[DPLDemoAction alloc] init];
+    action.actionURL  = link.URL;
+    action.actionName = @"Show: Product Inventory";
+    return action;
+}
 
 - (DPLDemoAction *)logHelloWorldAction {
     DPLMutableDeepLink *link = [[DPLMutableDeepLink alloc] initWithString:@"dpl://dpl.com/say/Hello/World"];


### PR DESCRIPTION
I've extended the DPLRouteHandler to allow the targetViewController for the given deep link to be passed back using a completion handler instead of synchronously.  In our current implementation, we have some preliminary data needed before the view controller can be successfully loaded, especially in cases where the app is currently not running in the background.  In our particular case, a given View Controller needs a GPS coordinate, and our architecture expects this lat/lon to be available and given to the VC as part of its startup routine instead of having the VC fetch the GPS itself.  By allowing us to return the VC asynchronously, we can get the GPS and have the VC ready for display as soon as the location comes back from CoreLocation.

I have also modified the sample applications, adding a new field to the data objects to represent the inventory of each product.  Fetching this inventory uses a new route handler that demonstrates, rather simply, a possible implementation of an asynchronous response.