### PR TITLE
Adds a method to get a Deep Link for a given URL from the Deep Link router

### DIFF
--- a/DeepLinkKit/Router/DPLDeepLinkRouter.h
+++ b/DeepLinkKit/Router/DPLDeepLinkRouter.h
@@ -68,7 +68,9 @@ typedef void(^DPLRouteCompletionBlock)(BOOL handled, NSError *error);
 - (void)registerBlock:(DPLRouteHandlerBlock)routeHandlerBlock forRoute:(NSString *)route;
 
 /**
- Returns a Deep link for the given URL, if one exists. Returns `nil` if no matching routes are found for the URL.
+ Evaluates the given URL to determine if it matches a registered route.
+ @param url The URL to be evaluated against registered routes.
+ @return A `DPLDeepLink` representing the URL if it matches a registered route.
  */
 - (nullable DPLDeepLink *)deepLinkForURL:(nonnull NSURL *)url;
 

--- a/DeepLinkKit/Router/DPLDeepLinkRouter.h
+++ b/DeepLinkKit/Router/DPLDeepLinkRouter.h
@@ -67,7 +67,10 @@ typedef void(^DPLRouteCompletionBlock)(BOOL handled, NSError *error);
  */
 - (void)registerBlock:(DPLRouteHandlerBlock)routeHandlerBlock forRoute:(NSString *)route;
 
-
+/**
+ Returns a Deep link for the given URL, if one exists. Returns `nil` if no matching routes are found for the URL.
+ */
+- (DPLDeepLink *)deepLinkForURL:(NSURL *)url;
 
 ///-------------------------
 /// @name Routing Deep Links

--- a/DeepLinkKit/Router/DPLDeepLinkRouter.h
+++ b/DeepLinkKit/Router/DPLDeepLinkRouter.h
@@ -70,7 +70,7 @@ typedef void(^DPLRouteCompletionBlock)(BOOL handled, NSError *error);
 /**
  Returns a Deep link for the given URL, if one exists. Returns `nil` if no matching routes are found for the URL.
  */
-- (DPLDeepLink *)deepLinkForURL:(NSURL *)url;
+- (nullable DPLDeepLink *)deepLinkForURL:(NSURL *)url;
 
 ///-------------------------
 /// @name Routing Deep Links

--- a/DeepLinkKit/Router/DPLDeepLinkRouter.h
+++ b/DeepLinkKit/Router/DPLDeepLinkRouter.h
@@ -70,7 +70,7 @@ typedef void(^DPLRouteCompletionBlock)(BOOL handled, NSError *error);
 /**
  Returns a Deep link for the given URL, if one exists. Returns `nil` if no matching routes are found for the URL.
  */
-- (nullable DPLDeepLink *)deepLinkForURL:(NSURL *)url;
+- (nullable DPLDeepLink *)deepLinkForURL:(nonnull NSURL *)url;
 
 ///-------------------------
 /// @name Routing Deep Links

--- a/DeepLinkKit/Router/DPLDeepLinkRouter.m
+++ b/DeepLinkKit/Router/DPLDeepLinkRouter.m
@@ -137,6 +137,19 @@
 }
 
 
+- (DPLDeepLink *)deepLinkForURL:(NSURL *)url {
+	for (NSString *route in self.routes) {
+		DPLRouteMatcher *matcher = [DPLRouteMatcher matcherWithRoute:route];
+		DPLDeepLink *deepLink = [matcher deepLinkWithURL:url];
+		if (deepLink) {
+			return deepLink;
+		}
+	}
+	
+	return nil;
+}
+
+
 - (BOOL)handleUserActivity:(NSUserActivity *)userActivity withCompletion:(DPLRouteCompletionBlock)completionHandler {
     if ([userActivity.activityType isEqualToString:NSUserActivityTypeBrowsingWeb]) {
         return [self handleURL:userActivity.webpageURL withCompletion:completionHandler];

--- a/DeepLinkKit/Router/DPLDeepLinkRouter.m
+++ b/DeepLinkKit/Router/DPLDeepLinkRouter.m
@@ -137,7 +137,7 @@
 }
 
 
-- (DPLDeepLink *)deepLinkForURL:(NSURL *)url {
+- (nullable DPLDeepLink *)deepLinkForURL:(NSURL *)url {
 	for (NSString *route in self.routes) {
 		DPLRouteMatcher *matcher = [DPLRouteMatcher matcherWithRoute:route];
 		DPLDeepLink *deepLink = [matcher deepLinkWithURL:url];

--- a/DeepLinkKit/Router/DPLDeepLinkRouter.m
+++ b/DeepLinkKit/Router/DPLDeepLinkRouter.m
@@ -137,7 +137,7 @@
 }
 
 
-- (nullable DPLDeepLink *)deepLinkForURL:(NSURL *)url {
+- (nullable DPLDeepLink *)deepLinkForURL:(nonnull NSURL *)url {
 	for (NSString *route in self.routes) {
 		DPLRouteMatcher *matcher = [DPLRouteMatcher matcherWithRoute:route];
 		DPLDeepLink *deepLink = [matcher deepLinkWithURL:url];

--- a/DeepLinkKit/Router/DPLDeepLinkRouter.m
+++ b/DeepLinkKit/Router/DPLDeepLinkRouter.m
@@ -117,15 +117,13 @@
     NSError      *error;
     DPLDeepLink  *deepLink;
     __block BOOL isHandled = NO;
-    for (NSString *route in self.routes) {
-        DPLRouteMatcher *matcher = [DPLRouteMatcher matcherWithRoute:route];
-        deepLink = [matcher deepLinkWithURL:url];
-        if (deepLink) {
-            isHandled = [self handleRoute:route withDeepLink:deepLink error:&error];
-            break;
-        }
-    }
-    
+	
+	NSArray *deepLinkAndRoute = [self deepLinkAndRouteForURL:url];
+	if ([deepLinkAndRoute count] == 2) {
+		deepLink = [deepLinkAndRoute firstObject];
+		isHandled = [self handleRoute:[deepLinkAndRoute lastObject] withDeepLink:deepLink error:&error];
+	}
+	
     if (!deepLink) {
         NSDictionary *userInfo = @{ NSLocalizedDescriptionKey: NSLocalizedString(@"The passed URL does not match a registered route.", nil) };
         error = [NSError errorWithDomain:DPLErrorDomain code:DPLRouteNotFoundError userInfo:userInfo];
@@ -138,11 +136,20 @@
 
 
 - (nullable DPLDeepLink *)deepLinkForURL:(nonnull NSURL *)url {
+	return [[self deepLinkAndRouteForURL:url] firstObject];
+}
+
+/**
+ Private method which returns an array containing two items: the deep link and the route for the given URL.
+ @param url The URL to be evaluated against registered routes.
+ @return An array containing two items: `DPLDeepLink` representing the URL and the route, if it matches a registered route.
+ */
+- (nullable NSArray *)deepLinkAndRouteForURL:(nonnull NSURL *)url {
 	for (NSString *route in self.routes) {
 		DPLRouteMatcher *matcher = [DPLRouteMatcher matcherWithRoute:route];
 		DPLDeepLink *deepLink = [matcher deepLinkWithURL:url];
 		if (deepLink) {
-			return deepLink;
+			return @[deepLink, route];
 		}
 	}
 	

--- a/Tests/Router/DPLDeepLinkRouterSpec.m
+++ b/Tests/Router/DPLDeepLinkRouterSpec.m
@@ -110,6 +110,37 @@ describe(@"Registering Routes", ^{
     });
 });
 
+describe(@"Checking Routes", ^{
+	
+	NSURL *url = [NSURL URLWithString:@"dlc://dlc.com/say/hello"];
+	
+	__block DPLDeepLinkRouter *router;
+	beforeEach(^{
+		router = [[DPLDeepLinkRouter alloc] init];
+	});
+	
+	it(@"returns a Deep Link object when given a matching URL", ^{
+		NSString *route = @"/say/hello";
+		router[route] = ^(DPLDeepLink *deepLink){};
+		
+		expect([router deepLinkForURL:url]).toNot.beNil();
+	});
+	
+	it(@"returns a Deep Link object when given a matching URL with a pattern", ^{
+		NSString *route = @"/say/:word";
+		router[route] = ^(DPLDeepLink *deepLink){};
+		
+		expect([router deepLinkForURL:url]).toNot.beNil();
+	});
+	
+	it(@"returns nil for a Deep Link when given a URL it can't route", ^{
+		NSString *route = @"/an/incorrect/route";
+		router[route] = ^(DPLDeepLink *deepLink){};
+		
+		expect([router deepLinkForURL:url]).to.beNil();
+	});
+});
+
 
 describe(@"Handling Routes", ^{
 


### PR DESCRIPTION
This PR adds a method to `DPLDeepLinkRouter` to get a `DPLDeepLink` for a given `URL`, if the router has a route that matches the URL. This is in effect saying “can the router handle this URL?” (but we thought it’d be more useful to return the deep link, if it exists). The method returns `nil` if the URL cannot be handled.