### PR TITLE
Carthage support

### DIFF
--- a/DeepLinkKit.podspec
+++ b/DeepLinkKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "DeepLinkKit"
-  s.version          = "1.2.1"
+  s.version          = "1.3.0"
   s.summary          = "A splendid route-matching, block-based way to handle your deep links."
   s.description      = <<-DESC
                        DeepLink Kit is a splendid route-handling block-based way to handle deep links. Use DeepLink Kit to parse incoming URLs, extract parameters from the host, url etc.. and even build outgoing deep links. All with a simple, block-based interface.

--- a/DeepLinkKit.xcodeproj/project.pbxproj
+++ b/DeepLinkKit.xcodeproj/project.pbxproj
@@ -792,7 +792,6 @@
 				BFDB96E91F3BFF8E001AE303 /* Sources */,
 				BFDB96EA1F3BFF8E001AE303 /* Frameworks */,
 				BFDB96EB1F3BFF8E001AE303 /* Headers */,
-				BFDB96EC1F3BFF8E001AE303 /* Resources */,
 			);
 			buildRules = (
 			);
@@ -896,13 +895,6 @@
 			files = (
 				62891E891B57FA9D00C2AF4F /* Images.xcassets in Resources */,
 				62891E881B57FA7F00C2AF4F /* Main.storyboard in Resources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		BFDB96EC1F3BFF8E001AE303 /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/DeepLinkKit.xcodeproj/project.pbxproj
+++ b/DeepLinkKit.xcodeproj/project.pbxproj
@@ -29,6 +29,20 @@
 		62EE96F61B570B10003D7564 /* DPLProductDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = DE025EB01A5F0D37007C4F3A /* DPLProductDataSource.m */; };
 		62EE96F71B570B13003D7564 /* DPLProduct.m in Sources */ = {isa = PBXBuildFile; fileRef = DE87B1F01A5DF49F00204A35 /* DPLProduct.m */; };
 		62EE96F81B570B16003D7564 /* DPLProductTableViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = DEAD327A19E079D3003C8D65 /* DPLProductTableViewController.m */; };
+		BFDB96F71F3C0011001AE303 /* NSString+DPLTrim.m in Sources */ = {isa = PBXBuildFile; fileRef = DE16E91B1A42720D00077E18 /* NSString+DPLTrim.m */; };
+		BFDB96F81F3C0011001AE303 /* NSString+DPLQuery.m in Sources */ = {isa = PBXBuildFile; fileRef = DE058E081A3B46F500147C04 /* NSString+DPLQuery.m */; };
+		BFDB96F91F3C0011001AE303 /* NSString+DPLJSON.m in Sources */ = {isa = PBXBuildFile; fileRef = DE3E61091A3B4485008D6DFC /* NSString+DPLJSON.m */; };
+		BFDB96FA1F3C0011001AE303 /* NSObject+DPLJSONObject.m in Sources */ = {isa = PBXBuildFile; fileRef = DECB32511A87E94B0071C76E /* NSObject+DPLJSONObject.m */; };
+		BFDB96FB1F3C0011001AE303 /* UINavigationController+DPLRouting.m in Sources */ = {isa = PBXBuildFile; fileRef = DE1B5F591CB301300086227F /* UINavigationController+DPLRouting.m */; };
+		BFDB96FC1F3C0011001AE303 /* DPLMatchResult.m in Sources */ = {isa = PBXBuildFile; fileRef = 83D34C3C1B03ECAD00BA6EF1 /* DPLMatchResult.m */; };
+		BFDB96FD1F3C0011001AE303 /* DPLRegularExpression.m in Sources */ = {isa = PBXBuildFile; fileRef = 83D34C3E1B03ECAD00BA6EF1 /* DPLRegularExpression.m */; };
+		BFDB96FE1F3C0011001AE303 /* DPLDeepLinkRouter.m in Sources */ = {isa = PBXBuildFile; fileRef = DE16E9211A42882F00077E18 /* DPLDeepLinkRouter.m */; };
+		BFDB96FF1F3C0011001AE303 /* DPLRouteHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = DEAC40711A5DA86A004A9095 /* DPLRouteHandler.m */; };
+		BFDB97001F3C0011001AE303 /* DPLRouteMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = DE16E9351A4289D500077E18 /* DPLRouteMatcher.m */; };
+		BFDB97011F3C0011001AE303 /* DPLDeepLink+AppLinks.m in Sources */ = {isa = PBXBuildFile; fileRef = DEA55ADC1A5F1A0700C312F5 /* DPLDeepLink+AppLinks.m */; };
+		BFDB97021F3C0011001AE303 /* DPLMutableDeepLink+AppLinks.m in Sources */ = {isa = PBXBuildFile; fileRef = DECB324C1A87C6750071C76E /* DPLMutableDeepLink+AppLinks.m */; };
+		BFDB97031F3C0011001AE303 /* DPLDeepLink.m in Sources */ = {isa = PBXBuildFile; fileRef = DE058E0D1A3B484A00147C04 /* DPLDeepLink.m */; };
+		BFDB97041F3C0011001AE303 /* DPLMutableDeepLink.m in Sources */ = {isa = PBXBuildFile; fileRef = DECB324A1A87C64E0071C76E /* DPLMutableDeepLink.m */; };
 		C63116DB33AD849960B2EA55 /* Pods_SenderDemo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4EA7EE926AA6053C8315A931 /* Pods_SenderDemo.framework */; };
 		DE025EB11A5F0D37007C4F3A /* DPLProductDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = DE025EB01A5F0D37007C4F3A /* DPLProductDataSource.m */; };
 		DE058E0A1A3B46FD00147C04 /* NSString_DPLQuerySpec.m in Sources */ = {isa = PBXBuildFile; fileRef = DE058E091A3B46FD00147C04 /* NSString_DPLQuerySpec.m */; };
@@ -1140,6 +1154,20 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BFDB97011F3C0011001AE303 /* DPLDeepLink+AppLinks.m in Sources */,
+				BFDB96FB1F3C0011001AE303 /* UINavigationController+DPLRouting.m in Sources */,
+				BFDB96F71F3C0011001AE303 /* NSString+DPLTrim.m in Sources */,
+				BFDB97031F3C0011001AE303 /* DPLDeepLink.m in Sources */,
+				BFDB96F91F3C0011001AE303 /* NSString+DPLJSON.m in Sources */,
+				BFDB97001F3C0011001AE303 /* DPLRouteMatcher.m in Sources */,
+				BFDB96FE1F3C0011001AE303 /* DPLDeepLinkRouter.m in Sources */,
+				BFDB96FD1F3C0011001AE303 /* DPLRegularExpression.m in Sources */,
+				BFDB96FC1F3C0011001AE303 /* DPLMatchResult.m in Sources */,
+				BFDB97041F3C0011001AE303 /* DPLMutableDeepLink.m in Sources */,
+				BFDB96F81F3C0011001AE303 /* NSString+DPLQuery.m in Sources */,
+				BFDB96FF1F3C0011001AE303 /* DPLRouteHandler.m in Sources */,
+				BFDB96FA1F3C0011001AE303 /* NSObject+DPLJSONObject.m in Sources */,
+				BFDB97021F3C0011001AE303 /* DPLMutableDeepLink+AppLinks.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/DeepLinkKit.xcodeproj/project.pbxproj
+++ b/DeepLinkKit.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		62EE96F61B570B10003D7564 /* DPLProductDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = DE025EB01A5F0D37007C4F3A /* DPLProductDataSource.m */; };
 		62EE96F71B570B13003D7564 /* DPLProduct.m in Sources */ = {isa = PBXBuildFile; fileRef = DE87B1F01A5DF49F00204A35 /* DPLProduct.m */; };
 		62EE96F81B570B16003D7564 /* DPLProductTableViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = DEAD327A19E079D3003C8D65 /* DPLProductTableViewController.m */; };
+		BFDB96F21F3BFF8E001AE303 /* DeepLinkKit.h in Headers */ = {isa = PBXBuildFile; fileRef = BFDB96F01F3BFF8E001AE303 /* DeepLinkKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C63116DB33AD849960B2EA55 /* Pods_SenderDemo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4EA7EE926AA6053C8315A931 /* Pods_SenderDemo.framework */; };
 		DE025EB11A5F0D37007C4F3A /* DPLProductDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = DE025EB01A5F0D37007C4F3A /* DPLProductDataSource.m */; };
 		DE058E0A1A3B46FD00147C04 /* NSString_DPLQuerySpec.m in Sources */ = {isa = PBXBuildFile; fileRef = DE058E091A3B46FD00147C04 /* NSString_DPLQuerySpec.m */; };
@@ -107,6 +108,9 @@
 		A12E3C55EEAB8A1FC1C6C397 /* Pods-Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tests.release.xcconfig"; path = "Pods/Target Support Files/Pods-Tests/Pods-Tests.release.xcconfig"; sourceTree = "<group>"; };
 		A9F173BA2E66B42CE6D24BF4 /* Pods_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B08420F70F2F29CEBA0D7B49 /* Pods-ReceiverDemoSwift.test.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ReceiverDemoSwift.test.xcconfig"; path = "Pods/Target Support Files/Pods-ReceiverDemoSwift/Pods-ReceiverDemoSwift.test.xcconfig"; sourceTree = "<group>"; };
+		BFDB96EE1F3BFF8E001AE303 /* DeepLinkKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DeepLinkKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		BFDB96F01F3BFF8E001AE303 /* DeepLinkKit.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DeepLinkKit.h; sourceTree = "<group>"; };
+		BFDB96F11F3BFF8E001AE303 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		C7BB11C353B6743FCCEC7DAA /* Pods-SenderDemo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SenderDemo.release.xcconfig"; path = "Pods/Target Support Files/Pods-SenderDemo/Pods-SenderDemo.release.xcconfig"; sourceTree = "<group>"; };
 		DE025EAF1A5F0D37007C4F3A /* DPLProductDataSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DPLProductDataSource.h; sourceTree = "<group>"; };
 		DE025EB01A5F0D37007C4F3A /* DPLProductDataSource.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DPLProductDataSource.m; sourceTree = "<group>"; };
@@ -229,6 +233,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		BFDB96EA1F3BFF8E001AE303 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		DEDB148A1A3F944D00A837F8 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -266,6 +277,7 @@
 				60FF7A9C1954A5C5007DD14C /* Pod Metadata */,
 				DE5DD32C19E0643F007FD439 /* DeepLinkKit */,
 				DEAD328119E079D3003C8D65 /* Tests */,
+				BFDB96EF1F3BFF8E001AE303 /* DeepLinkKit */,
 				6003F58C195388D20070C39A /* Frameworks */,
 				6003F58B195388D20070C39A /* Products */,
 				B7B006899D7C26BAA24F6B7E /* Pods */,
@@ -279,6 +291,7 @@
 				6003F5AE195388D20070C39A /* Tests.xctest */,
 				DEDB148D1A3F944D00A837F8 /* SenderDemo.app */,
 				62335DD61B57003300E3818C /* ReceiverDemoSwift.app */,
+				BFDB96EE1F3BFF8E001AE303 /* DeepLinkKit.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -356,6 +369,15 @@
 				A12E3C55EEAB8A1FC1C6C397 /* Pods-Tests.release.xcconfig */,
 			);
 			name = Pods;
+			sourceTree = "<group>";
+		};
+		BFDB96EF1F3BFF8E001AE303 /* DeepLinkKit */ = {
+			isa = PBXGroup;
+			children = (
+				BFDB96F01F3BFF8E001AE303 /* DeepLinkKit.h */,
+				BFDB96F11F3BFF8E001AE303 /* Info.plist */,
+			);
+			path = DeepLinkKit;
 			sourceTree = "<group>";
 		};
 		DE025EAC1A5F0CD3007C4F3A /* ProductDetail */ = {
@@ -673,6 +695,17 @@
 		};
 /* End PBXGroup section */
 
+/* Begin PBXHeadersBuildPhase section */
+		BFDB96EB1F3BFF8E001AE303 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BFDB96F21F3BFF8E001AE303 /* DeepLinkKit.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
 /* Begin PBXNativeTarget section */
 		6003F589195388D20070C39A /* ReceiverDemo */ = {
 			isa = PBXNativeTarget;
@@ -736,6 +769,24 @@
 			productReference = 62335DD61B57003300E3818C /* ReceiverDemoSwift.app */;
 			productType = "com.apple.product-type.application";
 		};
+		BFDB96ED1F3BFF8E001AE303 /* DeepLinkKit */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = BFDB96F61F3BFF8E001AE303 /* Build configuration list for PBXNativeTarget "DeepLinkKit" */;
+			buildPhases = (
+				BFDB96E91F3BFF8E001AE303 /* Sources */,
+				BFDB96EA1F3BFF8E001AE303 /* Frameworks */,
+				BFDB96EB1F3BFF8E001AE303 /* Headers */,
+				BFDB96EC1F3BFF8E001AE303 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = DeepLinkKit;
+			productName = DeepLinkKit;
+			productReference = BFDB96EE1F3BFF8E001AE303 /* DeepLinkKit.framework */;
+			productType = "com.apple.product-type.framework";
+		};
 		DEDB148C1A3F944D00A837F8 /* SenderDemo */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = DEDB14AD1A3F944E00A837F8 /* Build configuration list for PBXNativeTarget "SenderDemo" */;
@@ -773,6 +824,10 @@
 					62335DD51B57003300E3818C = {
 						CreatedOnToolsVersion = 6.4;
 					};
+					BFDB96ED1F3BFF8E001AE303 = {
+						CreatedOnToolsVersion = 8.3.3;
+						ProvisioningStyle = Automatic;
+					};
 					DEDB148C1A3F944D00A837F8 = {
 						CreatedOnToolsVersion = 6.1;
 					};
@@ -795,6 +850,7 @@
 				62335DD51B57003300E3818C /* ReceiverDemoSwift */,
 				DEDB148C1A3F944D00A837F8 /* SenderDemo */,
 				6003F5AD195388D20070C39A /* Tests */,
+				BFDB96ED1F3BFF8E001AE303 /* DeepLinkKit */,
 			);
 		};
 /* End PBXProject section */
@@ -824,6 +880,13 @@
 			files = (
 				62891E891B57FA9D00C2AF4F /* Images.xcassets in Resources */,
 				62891E881B57FA7F00C2AF4F /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		BFDB96EC1F3BFF8E001AE303 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1082,6 +1145,13 @@
 				62EE96F81B570B16003D7564 /* DPLProductTableViewController.m in Sources */,
 				62EE96F71B570B13003D7564 /* DPLProduct.m in Sources */,
 				62EE96F41B570891003D7564 /* DPLProductRouteHandler.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		BFDB96E91F3BFF8E001AE303 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1353,6 +1423,101 @@
 			};
 			name = Release;
 		};
+		BFDB96F31F3BFF8E001AE303 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = DeepLinkKit/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.usebutton.DeepLinkKit;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		BFDB96F41F3BFF8E001AE303 /* Test */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CODE_SIGN_IDENTITY = "";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = DeepLinkKit/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = com.usebutton.DeepLinkKit;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Test;
+		};
+		BFDB96F51F3BFF8E001AE303 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CODE_SIGN_IDENTITY = "";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = DeepLinkKit/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = com.usebutton.DeepLinkKit;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
 		DEA2AD611A4A8B0100F32289 /* Test */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -1534,6 +1699,15 @@
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
+		};
+		BFDB96F61F3BFF8E001AE303 /* Build configuration list for PBXNativeTarget "DeepLinkKit" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				BFDB96F31F3BFF8E001AE303 /* Debug */,
+				BFDB96F41F3BFF8E001AE303 /* Test */,
+				BFDB96F51F3BFF8E001AE303 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
 		};
 		DEDB14AD1A3F944E00A837F8 /* Build configuration list for PBXNativeTarget "SenderDemo" */ = {
 			isa = XCConfigurationList;

--- a/DeepLinkKit.xcodeproj/project.pbxproj
+++ b/DeepLinkKit.xcodeproj/project.pbxproj
@@ -29,7 +29,6 @@
 		62EE96F61B570B10003D7564 /* DPLProductDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = DE025EB01A5F0D37007C4F3A /* DPLProductDataSource.m */; };
 		62EE96F71B570B13003D7564 /* DPLProduct.m in Sources */ = {isa = PBXBuildFile; fileRef = DE87B1F01A5DF49F00204A35 /* DPLProduct.m */; };
 		62EE96F81B570B16003D7564 /* DPLProductTableViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = DEAD327A19E079D3003C8D65 /* DPLProductTableViewController.m */; };
-		BFDB96F21F3BFF8E001AE303 /* DeepLinkKit.h in Headers */ = {isa = PBXBuildFile; fileRef = BFDB96F01F3BFF8E001AE303 /* DeepLinkKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C63116DB33AD849960B2EA55 /* Pods_SenderDemo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4EA7EE926AA6053C8315A931 /* Pods_SenderDemo.framework */; };
 		DE025EB11A5F0D37007C4F3A /* DPLProductDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = DE025EB01A5F0D37007C4F3A /* DPLProductDataSource.m */; };
 		DE058E0A1A3B46FD00147C04 /* NSString_DPLQuerySpec.m in Sources */ = {isa = PBXBuildFile; fileRef = DE058E091A3B46FD00147C04 /* NSString_DPLQuerySpec.m */; };
@@ -109,7 +108,6 @@
 		A9F173BA2E66B42CE6D24BF4 /* Pods_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B08420F70F2F29CEBA0D7B49 /* Pods-ReceiverDemoSwift.test.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ReceiverDemoSwift.test.xcconfig"; path = "Pods/Target Support Files/Pods-ReceiverDemoSwift/Pods-ReceiverDemoSwift.test.xcconfig"; sourceTree = "<group>"; };
 		BFDB96EE1F3BFF8E001AE303 /* DeepLinkKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DeepLinkKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		BFDB96F01F3BFF8E001AE303 /* DeepLinkKit.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DeepLinkKit.h; sourceTree = "<group>"; };
 		BFDB96F11F3BFF8E001AE303 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		C7BB11C353B6743FCCEC7DAA /* Pods-SenderDemo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SenderDemo.release.xcconfig"; path = "Pods/Target Support Files/Pods-SenderDemo/Pods-SenderDemo.release.xcconfig"; sourceTree = "<group>"; };
 		DE025EAF1A5F0D37007C4F3A /* DPLProductDataSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DPLProductDataSource.h; sourceTree = "<group>"; };
@@ -277,7 +275,6 @@
 				60FF7A9C1954A5C5007DD14C /* Pod Metadata */,
 				DE5DD32C19E0643F007FD439 /* DeepLinkKit */,
 				DEAD328119E079D3003C8D65 /* Tests */,
-				BFDB96EF1F3BFF8E001AE303 /* DeepLinkKit */,
 				6003F58C195388D20070C39A /* Frameworks */,
 				6003F58B195388D20070C39A /* Products */,
 				B7B006899D7C26BAA24F6B7E /* Pods */,
@@ -369,15 +366,6 @@
 				A12E3C55EEAB8A1FC1C6C397 /* Pods-Tests.release.xcconfig */,
 			);
 			name = Pods;
-			sourceTree = "<group>";
-		};
-		BFDB96EF1F3BFF8E001AE303 /* DeepLinkKit */ = {
-			isa = PBXGroup;
-			children = (
-				BFDB96F01F3BFF8E001AE303 /* DeepLinkKit.h */,
-				BFDB96F11F3BFF8E001AE303 /* Info.plist */,
-			);
-			path = DeepLinkKit;
 			sourceTree = "<group>";
 		};
 		DE025EAC1A5F0CD3007C4F3A /* ProductDetail */ = {
@@ -526,6 +514,7 @@
 		DE5DD32C19E0643F007FD439 /* DeepLinkKit */ = {
 			isa = PBXGroup;
 			children = (
+				BFDB96F11F3BFF8E001AE303 /* Info.plist */,
 				DEB4EDBD1A4A726200F31D14 /* DeepLinkKit.h */,
 				DEC308D91CAD70A5006828A5 /* DeepLinkKit_Private.h */,
 				DE4128901A8BBE500089DAA2 /* AppLinks.h */,
@@ -700,7 +689,6 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BFDB96F21F3BFF8E001AE303 /* DeepLinkKit.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/DeepLinkKit.xcodeproj/project.pbxproj
+++ b/DeepLinkKit.xcodeproj/project.pbxproj
@@ -43,6 +43,13 @@
 		BFDB97021F3C0011001AE303 /* DPLMutableDeepLink+AppLinks.m in Sources */ = {isa = PBXBuildFile; fileRef = DECB324C1A87C6750071C76E /* DPLMutableDeepLink+AppLinks.m */; };
 		BFDB97031F3C0011001AE303 /* DPLDeepLink.m in Sources */ = {isa = PBXBuildFile; fileRef = DE058E0D1A3B484A00147C04 /* DPLDeepLink.m */; };
 		BFDB97041F3C0011001AE303 /* DPLMutableDeepLink.m in Sources */ = {isa = PBXBuildFile; fileRef = DECB324A1A87C64E0071C76E /* DPLMutableDeepLink.m */; };
+		BFDB97051F3C0048001AE303 /* DeepLinkKit.h in Headers */ = {isa = PBXBuildFile; fileRef = DEB4EDBD1A4A726200F31D14 /* DeepLinkKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BFDB97061F3C0048001AE303 /* DPLTargetViewControllerProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = DE99EF781A3B83D100CE3449 /* DPLTargetViewControllerProtocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BFDB97071F3C0048001AE303 /* DPLErrors.h in Headers */ = {isa = PBXBuildFile; fileRef = DEAC406E1A5D97EE004A9095 /* DPLErrors.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BFDB97081F3C0048001AE303 /* DPLDeepLinkRouter.h in Headers */ = {isa = PBXBuildFile; fileRef = DE16E9201A42882F00077E18 /* DPLDeepLinkRouter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BFDB97091F3C0048001AE303 /* DPLRouteHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = DEAC40701A5DA86A004A9095 /* DPLRouteHandler.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BFDB970A1F3C0048001AE303 /* DPLDeepLink.h in Headers */ = {isa = PBXBuildFile; fileRef = DE058E0C1A3B484A00147C04 /* DPLDeepLink.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BFDB970B1F3C0048001AE303 /* DPLMutableDeepLink.h in Headers */ = {isa = PBXBuildFile; fileRef = DECB32491A87C64E0071C76E /* DPLMutableDeepLink.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C63116DB33AD849960B2EA55 /* Pods_SenderDemo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4EA7EE926AA6053C8315A931 /* Pods_SenderDemo.framework */; };
 		DE025EB11A5F0D37007C4F3A /* DPLProductDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = DE025EB01A5F0D37007C4F3A /* DPLProductDataSource.m */; };
 		DE058E0A1A3B46FD00147C04 /* NSString_DPLQuerySpec.m in Sources */ = {isa = PBXBuildFile; fileRef = DE058E091A3B46FD00147C04 /* NSString_DPLQuerySpec.m */; };
@@ -703,6 +710,13 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BFDB97071F3C0048001AE303 /* DPLErrors.h in Headers */,
+				BFDB97051F3C0048001AE303 /* DeepLinkKit.h in Headers */,
+				BFDB97081F3C0048001AE303 /* DPLDeepLinkRouter.h in Headers */,
+				BFDB97091F3C0048001AE303 /* DPLRouteHandler.h in Headers */,
+				BFDB97061F3C0048001AE303 /* DPLTargetViewControllerProtocol.h in Headers */,
+				BFDB970B1F3C0048001AE303 /* DPLMutableDeepLink.h in Headers */,
+				BFDB970A1F3C0048001AE303 /* DPLDeepLink.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/DeepLinkKit.xcodeproj/xcshareddata/xcschemes/DeepLinkKit.xcscheme
+++ b/DeepLinkKit.xcodeproj/xcshareddata/xcschemes/DeepLinkKit.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0830"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BFDB96ED1F3BFF8E001AE303"
+               BuildableName = "DeepLinkKit.framework"
+               BlueprintName = "DeepLinkKit"
+               ReferencedContainer = "container:DeepLinkKit.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "BFDB96ED1F3BFF8E001AE303"
+            BuildableName = "DeepLinkKit.framework"
+            BlueprintName = "DeepLinkKit"
+            ReferencedContainer = "container:DeepLinkKit.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "BFDB96ED1F3BFF8E001AE303"
+            BuildableName = "DeepLinkKit.framework"
+            BlueprintName = "DeepLinkKit"
+            ReferencedContainer = "container:DeepLinkKit.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/DeepLinkKit/Info.plist
+++ b/DeepLinkKit/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/README.md
+++ b/README.md
@@ -29,13 +29,23 @@ pod try "DeepLinkKit"
 
 ## Installation
 
+### CocoaPods
 DeepLinkKit is available through [CocoaPods](http://cocoapods.org). To install
 the library, simply add the following line to your Podfile:
+
 ```ruby
 pod "DeepLinkKit"
 ```
 
-If you don't use CocoaPods, you can include all of the source files from the [DeepLinkKit directory](https://github.com/button/DeepLinkKit/tree/master/DeepLinkKit) in your project.
+### Carthage
+To install via Carthage, add the following line to your `Cartfile`:
+
+```text
+github "button/DeepLinkKit"
+```
+
+### Other
+If you don't use CocoaPods or Carthage, you can include all of the source files from the [DeepLinkKit directory](https://github.com/button/DeepLinkKit/tree/master/DeepLinkKit) in your project.
 
 ## Usage
 Add deep link support to your app in 5 minutes or less following these simple steps.


### PR DESCRIPTION
I'd love to be able to add Carthage support. I notice that there was a previous PR (#120) that seems to have stalled. Not sure if that is because the changes are not acceptable, or just look intimidating due to the `xcodeproj` file format.  

Anyway, this PR is slightly less large as it doesn't play with the umbrella header or the module map. I've also been very deliberate in how I've broken the commits up so you can see the specific changes that have been made along the way.  Specifically, this is what I did:

* Added a new Objective-C Cocoa Touch Framework target called `DeepLinkKit`
* When you do the above, it creates a new group in the navigator called `DeepLinkKit` with a new file called `Info.plist` and a reference to the existing `DeepLinkKit.h`. All I did was move the reference to `Info.plist` into the existing group of the same name, remove the duplicate reference to the `.h` file, and remove the duplicate group. Purely housekeeping to make the navigator look neat.
* I then selected all the `.m` files and added them to the newly created target
* Next, I grabbed all of the public `.h` files referenced in the `DeepLinkKit.h` umbrella header and made sure they were marked as public so they get copied into the `DeepLinkKit.framework/Headers` folder
* Removed an empty build phase step that gets added when you create the target
* Marked the scheme as public so that Carthage will find and compile
* Updated the install instructions to contain some instructions on how to use Carthage

So, even though the `project.pbxproj` has loads of changes, hopefully you can see from the above, they are pretty contained.