### PR TITLE
Adding support for query parameters in regular expression route matching

### DIFF
--- a/DeepLinkKit/RouteMatcher/DPLRouteMatcher.m
+++ b/DeepLinkKit/RouteMatcher/DPLRouteMatcher.m
@@ -38,6 +38,9 @@
     
     DPLDeepLink *deepLink       = [[DPLDeepLink alloc] initWithURL:url];
     NSString *deepLinkString    = [NSString stringWithFormat:@"%@%@", deepLink.URL.host, deepLink.URL.path];
+    if (deepLink.URL.query != nil && deepLink.URL.query.length > 0) {
+        deepLinkString = [NSString stringWithFormat:@"%@%@?%@", deepLink.URL.host, deepLink.URL.path, deepLink.URL.query];
+    }
     
     if (self.scheme.length && ![self.scheme isEqualToString:deepLink.URL.scheme]) {
         return nil;


### PR DESCRIPTION
A simple addition to allow routes with query parameters to be matched against regular expressions.
EX: `router["deeplink\\?type=feedback"] = FeedbackRouteHandler.self`