### PR TITLE
Fix Component two character at least

### DIFF
--- a/DeepLinkKit/Regex/DPLRegularExpression.m
+++ b/DeepLinkKit/Regex/DPLRegularExpression.m
@@ -1,6 +1,6 @@
 #import "DPLRegularExpression.h"
 
-static NSString * const DPLNamedGroupComponentPattern = @":[a-zA-Z0-9-_][^/]+";
+static NSString * const DPLNamedGroupComponentPattern = @":[a-zA-Z0-9-_]+[^/]*";
 static NSString * const DPLRouteParameterPattern      = @":[a-zA-Z0-9-_]+";
 static NSString * const DPLURLParameterPattern        = @"([^/]+)";
 


### PR DESCRIPTION
BUGFIX fix when route like “/say/:a/:b”,  the route would not/say/:a/:b, because DPLNamedGroupComponentPattern ask for at least two
character