### PR TITLE
Fix README formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,13 +58,12 @@ Add deep link support to your app in 5 minutes or less following these simple st
 **1. Make sure you have a URL scheme registered for your app in your Info.plist**
 <img src="https://cloud.githubusercontent.com/assets/1057077/5710380/8d913f3e-9a6f-11e4-83a2-49f6564d7a8f.png" width="410" />
 
-<br />
 **2. Import DeepLinkKit**
 
 ```objc
 #import <DeepLinkKit/DeepLinkKit.h>
 ```
-<br />
+
 **3. Create an instance of `DPLDeepLinkRouter` in your app delegate**
 
 ````objc
@@ -76,7 +75,7 @@ Add deep link support to your app in 5 minutes or less following these simple st
   return YES;
 }
 ````
-<br />
+
 **4. Register a route handler**
 
 Objective-C
@@ -95,7 +94,6 @@ self.router.register("/log/:message") { link in
 }
 ````
 
-<br />
 **5. Pass incoming URLs to the router**
 
 ```objc
@@ -107,8 +105,9 @@ self.router.register("/log/:message") { link in
   return [self.router handleURL:url withCompletion:NULL];
 }
 ```
+
 **6. Passing `NSUserActivity` objects to the router** (optional)
-<br/>
+
 _**Note:** If your application supports [Apple's new universal links](https://developer.apple.com/library/prerelease/ios/releasenotes/General/WhatsNewIniOS/Articles/iOS9.html#//apple_ref/doc/uid/TP40016198-DontLinkElementID_2), implement the following in your app delegate:_
 
 ```objc


### PR DESCRIPTION
The `<br />` tags are not necessary in Markdown. In this case they were preventing the bold text from rendering so I replaced them with hard returns. Now the bold text renders correctly.