### PR TITLE
Fix AppStore Submission when used via Carthage

### DIFF
--- a/DeepLinkKit/Info.plist
+++ b/DeepLinkKit/Info.plist
@@ -18,6 +18,8 @@
 	<string>1.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>MinimumOSVersion</key>
+	<string>8.0</string>
 	<key>NSPrincipalClass</key>
 	<string></string>
 </dict>


### PR DESCRIPTION
Embed Framework via Carthage results in following AppStore validation error:

![error](https://user-images.githubusercontent.com/18739004/77307154-0e40b680-6cf9-11ea-9a6a-cbedc218ee90.png)

Using `Carthage update --cache-builds --platform iOS` builds the framework with a default value for MinimumOSVersion of 7.0.

### Tasks
- [x] Add Key `MinimumOSVersion` with value `8.0` to info.plist