### PR TITLE
Add objective c nullability annotations

### DIFF
--- a/DeepLinkKit/Categories/NSObject+DPLJSONObject.h
+++ b/DeepLinkKit/Categories/NSObject+DPLJSONObject.h
@@ -6,7 +6,6 @@
  Returns a JSON compatible version of the receiver.
  
  @discussion
- 
  - NSDictionary and NSArray will call `DPLJSONObject' on all of their items.
  - Objects in an NSDictionary not keyed by an NSString will be removed.
  - NSNumbers that are NaN or Inf will be represented by a string.

--- a/DeepLinkKit/DeepLink/DPLDeepLink.h
+++ b/DeepLinkKit/DeepLink/DPLDeepLink.h
@@ -2,6 +2,8 @@
 
 @class DPLDeepLink;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface DPLDeepLink : NSObject <NSCopying, NSMutableCopying>
 
 
@@ -21,7 +23,7 @@
  The query parameters parsed from the incoming URL.
  @note If the URL conforms to the App Link standard, this will be the query parameters found on `target_url'.
  */
-@property (nonatomic, copy, readonly) NSDictionary *queryParameters;
+@property (nonatomic, copy, readonly, nullable) NSDictionary *queryParameters;
 
 
 /**
@@ -29,7 +31,7 @@
  @note Given a route `alert/:title/:message' and a path `button://alert/hello/world',
  the route parameters dictionary would be `@{ @"title": @"hello", @"message": @"world" }'.
  */
-@property (nonatomic, copy, readonly) NSDictionary *routeParameters;
+@property (nonatomic, copy, readonly, nullable) NSDictionary *routeParameters;
 
 
 /** 
@@ -42,7 +44,7 @@
  dpl://dpl.io/say/hello?dpl_callback_url=btn%3A%2F%2Fdpl.io%2Fsay%2Fhi
  @endcode
  */
-@property (nonatomic, strong, readonly) NSURL *callbackURL;
+@property (nonatomic, strong, readonly, nullable) NSURL *callbackURL;
 
 
 
@@ -57,7 +59,7 @@
  @endcode
  @note If the key is contained in both queryParameters and routeParameters, the value from routeParameters is returned.
  */
-- (id)objectForKeyedSubscript:(NSString *)key;
+- (nullable id)objectForKeyedSubscript:(NSString *)key;
 
 
 
@@ -73,3 +75,5 @@
 - (BOOL)isEqualToDeepLink:(DPLDeepLink *)deepLink;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/DeepLinkKit/DeepLink/DPLDeepLink.h
+++ b/DeepLinkKit/DeepLink/DPLDeepLink.h
@@ -23,7 +23,7 @@ NS_ASSUME_NONNULL_BEGIN
  The query parameters parsed from the incoming URL.
  @note If the URL conforms to the App Link standard, this will be the query parameters found on `target_url'.
  */
-@property (nonatomic, copy, readonly, nullable) NSDictionary *queryParameters;
+@property (nonatomic, copy, readonly) NSDictionary *queryParameters;
 
 
 /**
@@ -31,7 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
  @note Given a route `alert/:title/:message' and a path `button://alert/hello/world',
  the route parameters dictionary would be `@{ @"title": @"hello", @"message": @"world" }'.
  */
-@property (nonatomic, copy, readonly, nullable) NSDictionary *routeParameters;
+@property (nonatomic, copy, readonly) NSDictionary *routeParameters;
 
 
 /** 

--- a/DeepLinkKit/DeepLink/DPLDeepLink.m
+++ b/DeepLinkKit/DeepLink/DPLDeepLink.m
@@ -35,6 +35,7 @@ NSString * const DPLJSONEncodedFieldNamesKey = @"dpl:json-encoded-fields";
         }];
         
         _queryParameters = [NSDictionary dictionaryWithDictionary:mutableQueryParams];
+        _routeParameters = [NSDictionary dictionary];
     }
     return self;
 }

--- a/DeepLinkKit/DeepLink/DPLMutableDeepLink.h
+++ b/DeepLinkKit/DeepLink/DPLMutableDeepLink.h
@@ -1,5 +1,7 @@
 #import "DPLDeepLink.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  A mutable deep link for constructing deep links.
  */
@@ -13,15 +15,15 @@
 
 
 /// The scheme URL component, or nil if not present.
-@property (nonatomic, copy) NSString *scheme;
+@property (nonatomic, copy, nullable) NSString *scheme;
 
 
 /// The host URL subcomponent, or nil if not present.
-@property (nonatomic, copy) NSString *host;
+@property (nonatomic, copy, nullable) NSString *host;
 
 
 /// The path URL component, or nil if not present.
-@property (nonatomic, copy) NSString *path;
+@property (nonatomic, copy, nullable) NSString *path;
 
 
 /// The query URL component as a mutable dictionary. Default is empty.
@@ -43,7 +45,7 @@
  @param URLString The URL string for the deep link.
  @note If the URLString is malformed, nil is returned.
  */
-- (instancetype)initWithString:(NSString *)URLString;
+- (nullable instancetype)initWithString:(NSString *)URLString;
 
 
 
@@ -63,3 +65,5 @@
 - (void)setObject:(id)obj forKeyedSubscript:(NSString *)key;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/DeepLinkKit/Regex/DPLMatchResult.h
+++ b/DeepLinkKit/Regex/DPLMatchResult.h
@@ -3,6 +3,6 @@
 @interface DPLMatchResult : NSObject
 
 @property (nonatomic, assign, getter=isMatch) BOOL match;
-@property (nonatomic, strong) NSDictionary *namedProperties;
+@property (nonatomic, strong, nullable) NSDictionary *namedProperties;
 
 @end

--- a/DeepLinkKit/Regex/DPLRegularExpression.h
+++ b/DeepLinkKit/Regex/DPLRegularExpression.h
@@ -1,6 +1,8 @@
 @import Foundation;
 #import "DPLMatchResult.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface DPLRegularExpression : NSRegularExpression
 
 @property (nonatomic, strong) NSArray *groupNames;
@@ -10,3 +12,5 @@
 - (DPLMatchResult *)matchResultForString:(NSString *)str;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/DeepLinkKit/RouteHandler/DPLRouteHandler.h
+++ b/DeepLinkKit/RouteHandler/DPLRouteHandler.h
@@ -1,6 +1,8 @@
 @import UIKit;
 #import "DPLTargetViewControllerProtocol.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @class DPLDeepLink;
 
 /**
@@ -39,7 +41,7 @@
  @return A view controller conforming to the `DPLTargetViewController' protocol.
  @note Subclasses MUST override this method.
  */
-- (UIViewController <DPLTargetViewController> *)targetViewController;
+- (nullable UIViewController <DPLTargetViewController> *)targetViewController;
 
 
 /**
@@ -49,7 +51,7 @@
  @param deepLink A deep link instance.
  @return A view controller for presenting a target view controller.
  */
-- (UIViewController *)viewControllerForPresentingDeepLink:(DPLDeepLink *)deepLink;
+- (nullable UIViewController *)viewControllerForPresentingDeepLink:(DPLDeepLink *)deepLink;
 
 
 /**
@@ -69,3 +71,5 @@
                    inViewController:(UIViewController *)presentingViewController;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/DeepLinkKit/RouteMatcher/DPLRouteMatcher.h
+++ b/DeepLinkKit/RouteMatcher/DPLRouteMatcher.h
@@ -2,6 +2,8 @@
 
 @class DPLDeepLink;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface DPLRouteMatcher : NSObject
 
 /**
@@ -17,6 +19,8 @@
  @param url The url to be compared with the route.
  @return A DPLDeepLink instance if the URL matched the route, otherwise nil.
  */
-- (DPLDeepLink *)deepLinkWithURL:(NSURL *)url;
+- (nullable DPLDeepLink *)deepLinkWithURL:(NSURL *)url;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/DeepLinkKit/Router/DPLDeepLinkRouter.h
+++ b/DeepLinkKit/Router/DPLDeepLinkRouter.h
@@ -2,6 +2,7 @@
 
 @class DPLDeepLink;
 
+NS_ASSUME_NONNULL_BEGIN
 
 /**
  Defines the block type to be used as the handler when registering a route.
@@ -90,7 +91,7 @@ typedef void(^DPLRouteCompletionBlock)(BOOL handled, NSError *error);
  
  @see DPLRouteCompletionBlock
  */
-- (BOOL)handleURL:(NSURL *)url withCompletion:(DPLRouteCompletionBlock)completionHandler;
+- (BOOL)handleURL:(NSURL *)url withCompletion:(nullable DPLRouteCompletionBlock)completionHandler;
 
 
 /**
@@ -101,7 +102,7 @@ typedef void(^DPLRouteCompletionBlock)(BOOL handled, NSError *error);
  
  @see DPLRouteCompletionBlock
  */
-- (BOOL)handleUserActivity:(NSUserActivity *)userActivity withCompletion:(DPLRouteCompletionBlock)completionHandler;
+- (BOOL)handleUserActivity:(NSUserActivity *)userActivity withCompletion:(nullable DPLRouteCompletionBlock)completionHandler;
 
 
 ///--------------------
@@ -136,7 +137,7 @@ typedef void(^DPLRouteCompletionBlock)(BOOL handled, NSError *error);
  }
  @endcode
  */
-- (void)setObject:(id)obj forKeyedSubscript:(NSString *)key
+- (void)setObject:(nullable id)obj forKeyedSubscript:(NSString *)key
 NS_SWIFT_UNAVAILABLE("Available in Swift as: register(route: String, routeHandlerBlock: (DPLDeepLink) -> ())");
 
 
@@ -147,6 +148,7 @@ NS_SWIFT_UNAVAILABLE("Available in Swift as: register(route: String, routeHandle
  @endcode
  @note The type of the returned handler is the type you registered for that route.
  */
-- (id)objectForKeyedSubscript:(NSString *)key NS_SWIFT_UNAVAILABLE("Not Available");
+- (nullable id)objectForKeyedSubscript:(NSString *)key NS_SWIFT_UNAVAILABLE("Not Available");
 
 @end
+NS_ASSUME_NONNULL_END

--- a/SampleApps/ReceiverDemo/DPLReceiverAppDelegate.m
+++ b/SampleApps/ReceiverDemo/DPLReceiverAppDelegate.m
@@ -49,8 +49,8 @@
 
 
 - (BOOL)application:(UIApplication *)application
-        continueUserActivity:(NSUserActivity *)userActivity
-    restorationHandler:(void (^)(NSArray *))restorationHandler {
+    continueUserActivity:(NSUserActivity *)userActivity
+    restorationHandler:(void (^)(NSArray<id<UIUserActivityRestoring>> * _Nullable))restorationHandler {
     
     return [self.router handleUserActivity:userActivity withCompletion:NULL];
 }

--- a/SampleApps/ReceiverDemo/DPLReceiverAppDelegate.m
+++ b/SampleApps/ReceiverDemo/DPLReceiverAppDelegate.m
@@ -50,7 +50,7 @@
 
 - (BOOL)application:(UIApplication *)application
     continueUserActivity:(NSUserActivity *)userActivity
-    restorationHandler:(void (^ _Nonnull __strong)(NSArray<id<UIUserActivityRestoring>> * _Nullable __strong))restorationHandler {
+    restorationHandler:(void(^)(NSArray * __nullable restorableObjects))restorationHandler {
     
     return [self.router handleUserActivity:userActivity withCompletion:NULL];
 }

--- a/SampleApps/ReceiverDemo/DPLReceiverAppDelegate.m
+++ b/SampleApps/ReceiverDemo/DPLReceiverAppDelegate.m
@@ -50,7 +50,7 @@
 
 - (BOOL)application:(UIApplication *)application
     continueUserActivity:(NSUserActivity *)userActivity
-    restorationHandler:(void (^)(NSArray<id<UIUserActivityRestoring>> * _Nullable))restorationHandler {
+    restorationHandler:(void (^ _Nonnull __strong)(NSArray<id<UIUserActivityRestoring>> * _Nullable __strong))restorationHandler {
     
     return [self.router handleUserActivity:userActivity withCompletion:NULL];
 }

--- a/SampleApps/ReceiverDemoSwift/DPLReceiverSwiftAppDelegate.swift
+++ b/SampleApps/ReceiverDemoSwift/DPLReceiverSwiftAppDelegate.swift
@@ -10,7 +10,7 @@ class DPLReceiverSwiftAppDelegate: UIResponder, UIApplicationDelegate {
         
         // Register a block to a route (matches dpl:///product/93598)
         self.router.register("/product/:sku") { link in
-            print("\(link!.url.absoluteString)")
+            print("\(link.url.absoluteString)")
             
             if let rootViewController = application.keyWindow?.rootViewController as? UINavigationController {
                 if let storyboard = rootViewController.storyboard {
@@ -23,9 +23,7 @@ class DPLReceiverSwiftAppDelegate: UIResponder, UIApplicationDelegate {
         }
         
         self.router.register("/log/:message") { link in
-            if let link = link {
-                print("\(String(describing: link.routeParameters["message"]))")
-            }
+            print("\(String(describing: link.routeParameters["message"]))")
         }
         
         // Register a class to a route.

--- a/SampleApps/ReceiverDemoSwift/RouteHandlers/DPLProductRouteHandler.swift
+++ b/SampleApps/ReceiverDemoSwift/RouteHandlers/DPLProductRouteHandler.swift
@@ -6,6 +6,6 @@ open class DPLProductRouteHandler: DPLRouteHandler {
             return storyboard.instantiateViewController(withIdentifier: "detail") as! DPLProductDetailViewController
         }
         
-        return super.targetViewController()
+        return super.targetViewController()!
     }
 }


### PR DESCRIPTION
Hello

In the attached pull request I added nullability annotations for the relevant APIs, when calling objc methods from swift I really dislike not knowing for sure whether I can expect a null or not from that method.