### PR TITLE
Fix warning on Xcode12 (Set deployment target to 9.0 for DeepLinkKit framework target)

### DIFF
--- a/DeepLinkKit.xcodeproj/project.pbxproj
+++ b/DeepLinkKit.xcodeproj/project.pbxproj
@@ -1657,7 +1657,7 @@
 				GCC_NO_COMMON_BLOCKS = YES;
 				INFOPLIST_FILE = DeepLinkKit/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.usebutton.DeepLinkKit;
@@ -1689,7 +1689,7 @@
 				GCC_NO_COMMON_BLOCKS = YES;
 				INFOPLIST_FILE = DeepLinkKit/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.usebutton.DeepLinkKit;
@@ -1721,7 +1721,7 @@
 				GCC_NO_COMMON_BLOCKS = YES;
 				INFOPLIST_FILE = DeepLinkKit/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.usebutton.DeepLinkKit;

--- a/DeepLinkKit/Categories/NSObject+DPLJSONObject.h
+++ b/DeepLinkKit/Categories/NSObject+DPLJSONObject.h
@@ -6,7 +6,6 @@
  Returns a JSON compatible version of the receiver.
  
  @discussion
- 
  - NSDictionary and NSArray will call `DPLJSONObject' on all of their items.
  - Objects in an NSDictionary not keyed by an NSString will be removed.
  - NSNumbers that are NaN or Inf will be represented by a string.

--- a/DeepLinkKit/Info.plist
+++ b/DeepLinkKit/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>MinimumOSVersion</key>
-	<string>8.0</string>
+	<string>9.0</string>
 	<key>NSPrincipalClass</key>
 	<string></string>
 </dict>


### PR DESCRIPTION
When builds with cocoapods and Xcode Version 12.0 (12A7209), I get this warning in response:
>  'Empty paragraph passed to '@discussion' command'

> The iOS deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 8.0, but the range of supported deployment target versions is 9.0 to 14.0.99.

This PR sets IPHONEOS_DEPLOYMENT_TARGET to 9.0, which affects the MinimumOSVersion plist value distributed with compiled framework.

With this update, I no longer see the App Store Connect submission warning.